### PR TITLE
Require <getetag> eTag values

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/XmlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/XmlUtils.kt
@@ -6,6 +6,7 @@
 
 package at.bitfire.dav4jvm
 
+import at.bitfire.dav4jvm.exception.InvalidPropertyException
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import org.xmlpull.v1.XmlPullParserFactory
@@ -59,6 +60,16 @@ object XmlUtils {
 
         return text
     }
+
+    /**
+     * Same as [readText], but requires a [XmlPullParser.TEXT] value.
+     *
+     * @throws InvalidPropertyException when no text could be read
+     */
+    @Throws(InvalidPropertyException::class, IOException::class, XmlPullParserException::class)
+    fun requireReadText(parser: XmlPullParser): String =
+        readText(parser) ?:
+        throw InvalidPropertyException("XML text for ${parser.namespace}:${parser.name} must not be empty")
 
     @Throws(IOException::class, XmlPullParserException::class)
     fun readTextProperty(parser: XmlPullParser, name: Property.Name): String? {

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/InvalidPropertyException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/InvalidPropertyException.kt
@@ -1,0 +1,8 @@
+package at.bitfire.dav4jvm.exception
+
+/**
+ * Represents an invalid XML (WebDAV) property. This is for instance thrown
+ * when parsing something like `<multistatus>...<getetag><novalue/></getetag>`
+ * because a text value would be expected.
+ */
+class InvalidPropertyException(message: String): Exception(message)

--- a/src/test/kotlin/at/bitfire/dav4jvm/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/DavCollectionTest.kt
@@ -105,24 +105,24 @@ class DavCollectionTest {
                     assertTrue(response.isSuccess())
                     assertEquals(Response.HrefRelation.MEMBER, relation)
                     val eTag = response[GetETag::class.java]
-                    assertEquals("00001-abcd1", eTag?.eTag)
-                    assertTrue(eTag?.weak == false)
+                    assertEquals("00001-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
                     nrCalled++
                 }
                 url.resolve("/dav/vcard.vcf") -> {
                     assertTrue(response.isSuccess())
                     assertEquals(Response.HrefRelation.MEMBER, relation)
                     val eTag = response[GetETag::class.java]
-                    assertEquals("00002-abcd1", eTag?.eTag)
-                    assertTrue(eTag?.weak == false)
+                    assertEquals("00002-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
                     nrCalled++
                 }
                 url.resolve("/dav/calendar.ics") -> {
                     assertTrue(response.isSuccess())
                     assertEquals(Response.HrefRelation.MEMBER, relation)
                     val eTag = response[GetETag::class.java]
-                    assertEquals("00003-abcd1", eTag?.eTag)
-                    assertTrue(eTag?.weak == false)
+                    assertEquals("00003-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
                     nrCalled++
                 }
             }

--- a/src/test/kotlin/at/bitfire/dav4jvm/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/DavResourceTest.kt
@@ -245,7 +245,7 @@ class DavResourceTest {
 
             val eTag = GetETag.fromResponse(response)
             assertEquals("My Weak ETag", eTag!!.eTag)
-            assertTrue(eTag.weak!!)
+            assertTrue(eTag.weak)
             assertEquals("application/x-test-result".toMediaType(), GetContentType(response.body!!.contentType()!!).type)
         }
         assertTrue(called)
@@ -268,9 +268,9 @@ class DavResourceTest {
         dav.get("*/*", null) { response ->
             called = true
             assertEquals(sampleText, response.body!!.string())
-            val eTag = GetETag(response.header("ETag"))
+            val eTag = GetETag(response.header("ETag")!!)
             assertEquals("StrongETag", eTag.eTag)
-            assertFalse(eTag.weak!!)
+            assertFalse(eTag.weak)
         }
         assertTrue(called)
 
@@ -768,7 +768,7 @@ class DavResourceTest {
         dav.proppatch(
             setProperties = mapOf(Pair(Property.Name("sample", "setThis"), "Some Value")),
             removeProperties = listOf(Property.Name("sample", "removeThis"))
-        ) { response, hrefRelation ->
+        ) { _, hrefRelation ->
             called = true
             assertEquals(Response.HrefRelation.SELF, hrefRelation)
         }
@@ -804,7 +804,7 @@ class DavResourceTest {
             called = true
             val eTag = GetETag.fromResponse(response)!!
             assertEquals("Weak PUT ETag", eTag.eTag)
-            assertTrue(eTag.weak!!)
+            assertTrue(eTag.weak)
             assertEquals(response.request.url, dav.location)
         }
         assertTrue(called)
@@ -871,7 +871,7 @@ class DavResourceTest {
                     "  </response>" +
                     "</multistatus>"))
         var called = false
-        dav.search("<TEST/>") { response, hrefRelation, ->
+        dav.search("<TEST/>") { response, hrefRelation ->
             assertEquals(Response.HrefRelation.SELF, hrefRelation)
             assertEquals("Found something", response[DisplayName::class.java]?.displayName)
             called = true

--- a/src/test/kotlin/at/bitfire/dav4jvm/PropertyTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/PropertyTest.kt
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm
+
+import at.bitfire.dav4jvm.property.GetETag
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.StringReader
+
+class PropertyTest {
+
+    @Test
+    fun testParse_InvalidProperty() {
+        val parser = XmlPullParserFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newPullParser()
+        parser.setInput(StringReader("<multistatus xmlns='DAV:'><getetag/></multistatus>"))
+        do {
+            parser.next()
+        } while (parser.eventType != XmlPullParser.START_TAG && parser.name != "multistatus")
+
+        // we're now at the start of <multistatus>
+        assertEquals(XmlPullParser.START_TAG, parser.eventType)
+        assertEquals("multistatus", parser.name)
+
+        // parse invalid DAV:getetag
+        assertTrue(Property.parse(parser).isEmpty())
+
+        // we're now at the end of <multistatus>
+        assertEquals(XmlPullParser.END_TAG, parser.eventType)
+        assertEquals("multistatus", parser.name)
+    }
+
+    @Test
+    fun testParse_ValidProperty() {
+        val parser = XmlPullParserFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newPullParser()
+        parser.setInput(StringReader("<multistatus xmlns='DAV:'><getetag>12345</getetag></multistatus>"))
+        do {
+            parser.next()
+        } while (parser.eventType != XmlPullParser.START_TAG && parser.name != "multistatus")
+
+        // we're now at the start of <multistatus>
+        assertEquals(XmlPullParser.START_TAG, parser.eventType)
+        assertEquals("multistatus", parser.name)
+
+        val etag = Property.parse(parser).first()
+        assertEquals(GetETag("12345"), etag)
+
+        // we're now at the end of <multistatus>
+        assertEquals(XmlPullParser.END_TAG, parser.eventType)
+        assertEquals("multistatus", parser.name)
+    }
+
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/property/GetETagTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/property/GetETagTest.kt
@@ -6,19 +6,11 @@ import org.junit.Test
 class GetETagTest: PropertyTest() {
 
     @Test
-    fun testGetETag_NoText() {
-        val results = parseProperty("<getetag xmlns=\"DAV:\"><invalid/></getetag>")
-        val getETag = results.first() as GetETag
-        assertNull(getETag.eTag)
-        assertNull(getETag.weak)
-    }
-
-    @Test
     fun testGetETag_Strong() {
         val results = parseProperty("<getetag xmlns=\"DAV:\">\"Correct strong ETag\"</getetag>")
         val getETag = results.first() as GetETag
         assertEquals("Correct strong ETag", getETag.eTag)
-        assertFalse(getETag.weak!!)
+        assertFalse(getETag.weak)
     }
 
     @Test
@@ -26,7 +18,7 @@ class GetETagTest: PropertyTest() {
         val results = parseProperty("<getetag xmlns=\"DAV:\">Strong ETag without quotes</getetag>")
         val getETag = results.first() as GetETag
         assertEquals("Strong ETag without quotes", getETag.eTag)
-        assertFalse(getETag.weak!!)
+        assertFalse(getETag.weak)
     }
 
     @Test
@@ -34,7 +26,15 @@ class GetETagTest: PropertyTest() {
         val results = parseProperty("<getetag xmlns=\"DAV:\">W/\"Correct weak ETag\"</getetag>")
         val getETag = results.first() as GetETag
         assertEquals("Correct weak ETag", getETag.eTag)
-        assertTrue(getETag.weak!!)
+        assertTrue(getETag.weak)
+    }
+
+    @Test
+    fun testGetETag_Weak_Empty() {
+        val results = parseProperty("<getetag xmlns=\"DAV:\">W/</getetag>")
+        val getETag = results.first() as GetETag
+        assertEquals("", getETag.eTag)
+        assertTrue(getETag.weak)
     }
 
     @Test
@@ -42,7 +42,7 @@ class GetETagTest: PropertyTest() {
         val results = parseProperty("<getetag xmlns=\"DAV:\">W/Weak ETag without quotes</getetag>")
         val getETag = results.first() as GetETag
         assertEquals("Weak ETag without quotes", getETag.eTag)
-        assertTrue(getETag.weak!!)
+        assertTrue(getETag.weak)
     }
 
 }


### PR DESCRIPTION
- introduce XmlUtils.requireReadText()
- GetETag: require input text so that the value fields don't have to be nullable