### PR TITLE
Add WebDAV-Push draft properties

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/HttpUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/HttpUtils.kt
@@ -58,15 +58,15 @@ object HttpUtils {
     /**
      * Parses a HTTP-date according to RFC 7231 section 7.1.1.1.
      *
-     * @param dateStr date formatted in one of the three accepted formats:
+     * @param dateStr date-time formatted in one of the three accepted formats:
      *
      *   - preferred format (`IMF-fixdate`)
      *   - obsolete RFC 850 format
      *   - ANSI C's `asctime()` format
      *
-     * @return date, or null if date could not be parsed
+     * @return date-time, or null if date could not be parsed
      */
-    fun parseDate(dateStr: String): ZonedDateTime? {
+    fun parseDate(dateStr: String): Instant? {
         val zonedFormats = arrayOf(
             // preferred format
             httpDateFormat,
@@ -78,7 +78,7 @@ object HttpUtils {
         // try the two formats with zone info
         for (format in zonedFormats)
             try {
-                return ZonedDateTime.parse(dateStr, format)
+                return ZonedDateTime.parse(dateStr, format).toInstant()
             } catch (ignored: DateTimeParseException) {
             }
 
@@ -86,7 +86,7 @@ object HttpUtils {
         try {
             val formatC = DateTimeFormatter.ofPattern("EEE MMM ppd HH:mm:ss yyyy", Locale.US)
             val local = LocalDateTime.parse(dateStr, formatC)
-            return local.atZone(ZoneOffset.UTC)
+            return local.atZone(ZoneOffset.UTC).toInstant()
         } catch (ignored: DateTimeParseException) {
         }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
@@ -24,6 +24,7 @@ import at.bitfire.dav4jvm.property.carddav.AddressbookDescription
 import at.bitfire.dav4jvm.property.carddav.AddressbookHomeSet
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.push.PushSubscribe
+import at.bitfire.dav4jvm.property.push.PushTransports
 import at.bitfire.dav4jvm.property.webdav.AddMember
 import at.bitfire.dav4jvm.property.webdav.CreationDate
 import at.bitfire.dav4jvm.property.webdav.CurrentUserPrincipal
@@ -81,6 +82,7 @@ object PropertyRegistry {
             at.bitfire.dav4jvm.property.carddav.MaxResourceSize.Factory,
             Owner.Factory,
             PushSubscribe.Factory,
+            PushTransports.Factory,
             QuotaAvailableBytes.Factory,
             QuotaUsedBytes.Factory,
             ResourceType.Factory,

--- a/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
@@ -25,7 +25,9 @@ import at.bitfire.dav4jvm.property.carddav.AddressbookHomeSet
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.push.PushSubscribe
 import at.bitfire.dav4jvm.property.push.PushTransports
+import at.bitfire.dav4jvm.property.push.Subscription
 import at.bitfire.dav4jvm.property.push.Topic
+import at.bitfire.dav4jvm.property.push.WebPushSubscription
 import at.bitfire.dav4jvm.property.webdav.AddMember
 import at.bitfire.dav4jvm.property.webdav.CreationDate
 import at.bitfire.dav4jvm.property.webdav.CurrentUserPrincipal
@@ -89,12 +91,14 @@ object PropertyRegistry {
             ResourceType.Factory,
             ScheduleTag.Factory,
             Source.Factory,
+            Subscription.Factory,
             SupportedAddressData.Factory,
             SupportedCalendarComponentSet.Factory,
             SupportedCalendarData.Factory,
             SupportedReportSet.Factory,
             SyncToken.Factory,
-            Topic.Factory
+            Topic.Factory,
+            WebPushSubscription.Factory
         ))
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
@@ -23,6 +23,7 @@ import at.bitfire.dav4jvm.property.carddav.AddressData
 import at.bitfire.dav4jvm.property.carddav.AddressbookDescription
 import at.bitfire.dav4jvm.property.carddav.AddressbookHomeSet
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
+import at.bitfire.dav4jvm.property.push.PushSubscribe
 import at.bitfire.dav4jvm.property.webdav.AddMember
 import at.bitfire.dav4jvm.property.webdav.CreationDate
 import at.bitfire.dav4jvm.property.webdav.CurrentUserPrincipal
@@ -79,6 +80,7 @@ object PropertyRegistry {
             at.bitfire.dav4jvm.property.caldav.MaxResourceSize.Factory,
             at.bitfire.dav4jvm.property.carddav.MaxResourceSize.Factory,
             Owner.Factory,
+            PushSubscribe.Factory,
             QuotaAvailableBytes.Factory,
             QuotaUsedBytes.Factory,
             ResourceType.Factory,

--- a/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/PropertyRegistry.kt
@@ -25,6 +25,7 @@ import at.bitfire.dav4jvm.property.carddav.AddressbookHomeSet
 import at.bitfire.dav4jvm.property.carddav.SupportedAddressData
 import at.bitfire.dav4jvm.property.push.PushSubscribe
 import at.bitfire.dav4jvm.property.push.PushTransports
+import at.bitfire.dav4jvm.property.push.Topic
 import at.bitfire.dav4jvm.property.webdav.AddMember
 import at.bitfire.dav4jvm.property.webdav.CreationDate
 import at.bitfire.dav4jvm.property.webdav.CurrentUserPrincipal
@@ -92,7 +93,8 @@ object PropertyRegistry {
             SupportedCalendarComponentSet.Factory,
             SupportedCalendarData.Factory,
             SupportedReportSet.Factory,
-            SyncToken.Factory
+            SyncToken.Factory,
+            Topic.Factory
         ))
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableException.kt
@@ -24,15 +24,15 @@ class ServiceUnavailableException: HttpException {
         // HTTP-date    = rfc1123-date | rfc850-date | asctime-date
 
         response.header("Retry-After")?.let { after ->
-            retryAfter = HttpUtils.parseDate(after)?.toInstant() ?:
-                    // not a HTTP-date, must be delta-seconds
-                    try {
-                        val seconds = after.toLong()
-                        Instant.now().plusSeconds(seconds)
-                    } catch (e: NumberFormatException) {
-                        Dav4jvm.log.log(Level.WARNING, "Received Retry-After which was not a HTTP-date nor delta-seconds: $after", e)
-                        null
-                    }
+            retryAfter = HttpUtils.parseDate(after) ?:
+                // not a HTTP-date, must be delta-seconds
+                try {
+                    val seconds = after.toLong()
+                    Instant.now().plusSeconds(seconds)
+                } catch (e: NumberFormatException) {
+                    Dav4jvm.log.log(Level.WARNING, "Received Retry-After which was not a HTTP-date nor delta-seconds: $after", e)
+                    null
+                }
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
@@ -6,16 +6,13 @@
 
 package at.bitfire.dav4jvm.property.push
 
-import at.bitfire.dav4jvm.Dav4jvm
 import at.bitfire.dav4jvm.HttpUtils
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import at.bitfire.dav4jvm.XmlUtils.propertyName
 import org.xmlpull.v1.XmlPullParser
-import org.xmlpull.v1.XmlPullParserException
 import java.time.Instant
-import java.util.logging.Level
 
 class PushSubscribe: Property {
 
@@ -25,12 +22,11 @@ class PushSubscribe: Property {
         val NAME = Property.Name(NS_WEBDAV_PUSH, "push-subscribe")
 
         val EXPIRES = Property.Name(NS_WEBDAV_PUSH, "expires")
-        val WEB_PUSH_SUBSCRIPTION = Property.Name(NS_WEBDAV_PUSH, "web-push-subscription")
 
     }
 
     var expires: Instant? = null
-    var webPushSubscription: WebPushSubscription? = null
+    var subscription: Subscription? = null
 
 
     object Factory: PropertyFactory {
@@ -40,24 +36,19 @@ class PushSubscribe: Property {
         override fun create(parser: XmlPullParser): PushSubscribe? {
             val subscribe = PushSubscribe()
 
-            try {
-                val depth = parser.depth
-                var eventType = parser.eventType
-                while (!(eventType == XmlPullParser.END_TAG && parser.depth == depth)) {
-                    if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
-                        when (parser.propertyName()) {
-                            EXPIRES -> {
-                                val expiresDate = XmlUtils.requireReadText(parser)
-                                subscribe.expires = HttpUtils.parseDate(expiresDate)
-                            }
-                            WEB_PUSH_SUBSCRIPTION ->
-                                subscribe.webPushSubscription = WebPushSubscription.Factory.create(parser)
+            val depth = parser.depth
+            var eventType = parser.eventType
+            while (!(eventType == XmlPullParser.END_TAG && parser.depth == depth)) {
+                if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
+                    when (parser.propertyName()) {
+                        EXPIRES -> {
+                            val expiresDate = XmlUtils.requireReadText(parser)
+                            subscribe.expires = HttpUtils.parseDate(expiresDate)
                         }
-                    eventType = parser.next()
-                }
-            } catch (e: XmlPullParserException) {
-                Dav4jvm.log.log(Level.SEVERE, "Couldn't parse <push-subscribe>", e)
-                return null
+                        Subscription.NAME ->
+                            subscribe.subscription = Subscription.Factory.create(parser)
+                    }
+                eventType = parser.next()
             }
 
             return subscribe

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+import at.bitfire.dav4jvm.Dav4jvm
+import at.bitfire.dav4jvm.HttpUtils
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import at.bitfire.dav4jvm.XmlUtils.propertyName
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.time.Instant
+import java.util.logging.Level
+
+class PushSubscribe: Property {
+
+    companion object {
+
+        @JvmField
+        val NAME = Property.Name(NS_WEBDAV_PUSH, "push-subscribe")
+
+        val EXPIRES = Property.Name(NS_WEBDAV_PUSH, "expires")
+        val WEB_PUSH_SUBSCRIPTION = Property.Name(NS_WEBDAV_PUSH, "web-push-subscription")
+
+    }
+
+    var expires: Instant? = null
+    var webPushSubscription: WebPushSubscription? = null
+
+
+    object Factory: PropertyFactory {
+
+        override fun getName() = NAME
+
+        override fun create(parser: XmlPullParser): PushSubscribe? {
+            val subscribe = PushSubscribe()
+
+            try {
+                val depth = parser.depth
+                var eventType = parser.eventType
+                while (!(eventType == XmlPullParser.END_TAG && parser.depth == depth)) {
+                    if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
+                        when (parser.propertyName()) {
+                            EXPIRES -> {
+                                val expiresDate = XmlUtils.requireReadText(parser)
+                                subscribe.expires = HttpUtils.parseDate(expiresDate)
+                            }
+                            WEB_PUSH_SUBSCRIPTION ->
+                                subscribe.webPushSubscription = WebPushSubscription.Factory.create(parser)
+                        }
+                    eventType = parser.next()
+                }
+            } catch (e: XmlPullParserException) {
+                Dav4jvm.log.log(Level.SEVERE, "Couldn't parse <push-subscribe>", e)
+                return null
+            }
+
+            return subscribe
+        }
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushSubscribe.kt
@@ -14,6 +14,11 @@ import at.bitfire.dav4jvm.XmlUtils.propertyName
 import org.xmlpull.v1.XmlPullParser
 import java.time.Instant
 
+/**
+ * Represents a `{DAV:Push}push-subscribe` property.
+ *
+ * Experimental! See https://github.com/bitfireAT/webdav-push/
+ */
 class PushSubscribe: Property {
 
     companion object {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushTransports.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushTransports.kt
@@ -12,6 +12,11 @@ import at.bitfire.dav4jvm.XmlUtils
 import at.bitfire.dav4jvm.XmlUtils.propertyName
 import org.xmlpull.v1.XmlPullParser
 
+/**
+ * Represents a `{DAV:Push}push-transports` property.
+ *
+ * Experimental! See https://github.com/bitfireAT/webdav-push/
+ */
 class PushTransports private constructor(
     val transports: Set<Property.Name>
 ): Property {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushTransports.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/PushTransports.kt
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import at.bitfire.dav4jvm.XmlUtils.propertyName
+import org.xmlpull.v1.XmlPullParser
+
+class PushTransports private constructor(
+    val transports: Set<Property.Name>
+): Property {
+
+    companion object {
+        @JvmField
+        val NAME = Property.Name(NS_WEBDAV_PUSH, "push-transports")
+
+        val TRANSPORT = Property.Name(NS_WEBDAV_PUSH, "transport")
+        val WEB_PUSH = Property.Name(NS_WEBDAV_PUSH, "web-push")
+    }
+
+    fun hasWebPush() = transports.contains(WEB_PUSH)
+
+
+    object Factory: PropertyFactory {
+
+        override fun getName() = NAME
+
+        override fun create(parser: XmlPullParser): PushTransports {
+            val transports = mutableListOf<Property.Name>()
+            XmlUtils.processTag(parser, TRANSPORT) {
+                val depth = parser.depth
+                var eventType = parser.eventType
+                while (!(eventType == XmlPullParser.END_TAG && parser.depth == depth)) {
+                    if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
+                        transports += parser.propertyName()
+                    eventType = parser.next()
+                }
+            }
+            return PushTransports(transports.toSet())
+        }
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/Subscription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/Subscription.kt
@@ -11,6 +11,11 @@ import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import org.xmlpull.v1.XmlPullParser
 
+/**
+ * Represents a `{DAV:Push}subscription` property.
+ *
+ * Experimental! See https://github.com/bitfireAT/webdav-push/
+ */
 class Subscription private constructor(
     val webPushSubscription: WebPushSubscription
 ): Property {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/Subscription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/Subscription.kt
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import org.xmlpull.v1.XmlPullParser
+
+class Subscription private constructor(
+    val webPushSubscription: WebPushSubscription
+): Property {
+
+    companion object {
+
+        @JvmField
+        val NAME = Property.Name(NS_WEBDAV_PUSH, "subscription")
+
+    }
+
+
+    object Factory: PropertyFactory {
+
+        override fun getName() = NAME
+
+        override fun create(parser: XmlPullParser): Subscription? {
+            // currently we only support WebPushSubscription
+            var webPushSubscription: WebPushSubscription? = null
+
+            XmlUtils.processTag(parser, WebPushSubscription.NAME) {
+                webPushSubscription = WebPushSubscription.Factory.create(parser)
+            }
+
+            return webPushSubscription?.let {
+                Subscription(webPushSubscription = it)
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/Topic.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/Topic.kt
@@ -11,6 +11,11 @@ import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import org.xmlpull.v1.XmlPullParser
 
+/**
+ * Represents a `{DAV:Push}topic` property.
+ *
+ * Experimental! See https://github.com/bitfireAT/webdav-push/
+ */
 class Topic private constructor(
     val topic: String
 ): Property {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/Topic.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/Topic.kt
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import org.xmlpull.v1.XmlPullParser
+
+class Topic private constructor(
+    val topic: String
+): Property {
+
+    companion object {
+
+        @JvmField
+        val NAME = Property.Name(NS_WEBDAV_PUSH, "topic")
+
+    }
+
+
+    object Factory: PropertyFactory {
+
+        override fun getName() = NAME
+
+        override fun create(parser: XmlPullParser) =
+            Topic(XmlUtils.requireReadText(parser))
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
@@ -6,13 +6,10 @@
 
 package at.bitfire.dav4jvm.property.push
 
-import at.bitfire.dav4jvm.Dav4jvm
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import org.xmlpull.v1.XmlPullParser
-import org.xmlpull.v1.XmlPullParserException
-import java.util.logging.Level
 
 class WebPushSubscription: Property {
 
@@ -32,18 +29,10 @@ class WebPushSubscription: Property {
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser): WebPushSubscription? {
-            val subscription = WebPushSubscription()
-
-            try {
-                subscription.pushResource = XmlUtils.readTextProperty(parser, PUSH_RESOURCE)
-            } catch (e: XmlPullParserException) {
-                Dav4jvm.log.log(Level.SEVERE, "Couldn't parse <web-push-subscription>", e)
-                return null
+        override fun create(parser: XmlPullParser) =
+            WebPushSubscription().apply {
+                pushResource = XmlUtils.readTextProperty(parser, PUSH_RESOURCE)
             }
-
-            return subscription
-        }
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+import at.bitfire.dav4jvm.Dav4jvm
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.util.logging.Level
+
+class WebPushSubscription: Property {
+
+    companion object {
+
+        @JvmField
+        val NAME = Property.Name(NS_WEBDAV_PUSH, "web-push-subscription")
+
+        val PUSH_RESOURCE = Property.Name(NS_WEBDAV_PUSH, "push-resource")
+
+    }
+
+    var pushResource: String? = null
+
+
+    object Factory: PropertyFactory {
+
+        override fun getName() = NAME
+
+        override fun create(parser: XmlPullParser): WebPushSubscription? {
+            val subscription = WebPushSubscription()
+
+            try {
+                subscription.pushResource = XmlUtils.readTextProperty(parser, PUSH_RESOURCE)
+            } catch (e: XmlPullParserException) {
+                Dav4jvm.log.log(Level.SEVERE, "Couldn't parse <web-push-subscription>", e)
+                return null
+            }
+
+            return subscription
+        }
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/WebPushSubscription.kt
@@ -11,6 +11,11 @@ import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import org.xmlpull.v1.XmlPullParser
 
+/**
+ * Represents a `{DAV:Push}web-push-subscription` property.
+ *
+ * Experimental! See https://github.com/bitfireAT/webdav-push/
+ */
 class WebPushSubscription: Property {
 
     companion object {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
@@ -1,0 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package at.bitfire.dav4jvm.property.push
+
+const val NS_WEBDAV_PUSH = "DAV:Push"

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
@@ -6,4 +6,8 @@
 
 package at.bitfire.dav4jvm.property.push
 
+/**
+ * XML namespace of WebDAV-Push (draft), see:
+ * https://github.com/bitfireAT/webdav-push/
+ */
 const val NS_WEBDAV_PUSH = "DAV:Push"

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/push/namespace.kt
@@ -9,5 +9,7 @@ package at.bitfire.dav4jvm.property.push
 /**
  * XML namespace of WebDAV-Push (draft), see:
  * https://github.com/bitfireAT/webdav-push/
+ *
+ * Experimental!
  */
 const val NS_WEBDAV_PUSH = "DAV:Push"

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
@@ -43,7 +43,7 @@ data class CurrentUserPrivilegeSet(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser): CurrentUserPrivilegeSet? {
+        override fun create(parser: XmlPullParser): CurrentUserPrivilegeSet {
             // <!ELEMENT current-user-privilege-set (privilege*)>
             // <!ELEMENT privilege ANY>
             val privs = CurrentUserPrivilegeSet()

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetLastModified.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetLastModified.kt
@@ -12,10 +12,10 @@ import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlUtils
 import org.xmlpull.v1.XmlPullParser
-import java.time.ZonedDateTime
+import java.time.Instant
 
 data class GetLastModified(
-    var lastModified: ZonedDateTime
+    var lastModified: Instant
 ): Property {
 
     companion object {

--- a/src/test/kotlin/at/bitfire/dav4jvm/HttpUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/HttpUtilsTest.kt
@@ -11,6 +11,7 @@ import org.apache.commons.lang3.time.TimeZones
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -50,32 +51,32 @@ class HttpUtilsTest {
     @Test
     fun parseDate_IMF_FixDate() {
         // RFC 7231 IMF-fixdate (preferred format)
-        assertEquals(784111777L, HttpUtils.parseDate("Sun, 06 Nov 1994 08:49:37 GMT")?.toEpochSecond())
+        assertEquals(Instant.ofEpochSecond(784111777), HttpUtils.parseDate("Sun, 06 Nov 1994 08:49:37 GMT"))
     }
 
     @Test
     fun parseDate_RFC850_1994() {
         // obsolete RFC 850 format – fails when run after year 2000 because 06 Nov 2094 (!) is not a Sunday
-        assertNull(HttpUtils.parseDate("Sun, 06-Nov-94 08:49:37 GMT")?.toEpochSecond())
+        assertNull(HttpUtils.parseDate("Sun, 06-Nov-94 08:49:37 GMT"))
     }
 
     @Test
     fun parseDate_RFC850_2004_CEST() {
         // obsolete RFC 850 format with European time zone
-        assertEquals(1689317377L, HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 CEST")?.toEpochSecond())
+        assertEquals(Instant.ofEpochSecond(1689317377), HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 CEST"))
     }
 
     @Test
     fun parseDate_RFC850_2004_GMT() {
         // obsolete RFC 850 format
-        assertEquals(1689324577L, HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 GMT")?.toEpochSecond())
+        assertEquals(Instant.ofEpochSecond(1689324577), HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 GMT"))
     }
 
     @Test
     fun parseDate_ANSI_C() {
         // ANSI C's asctime() format
         Dav4jvm.log.info("Expected date: " + DateTimeFormatter.ofPattern("EEE MMM ppd HH:mm:ss yyyy", Locale.US).format(ZonedDateTime.now()))
-        assertEquals(784111777L, HttpUtils.parseDate("Sun Nov  6 08:49:37 1994")?.toEpochSecond())
+        assertEquals(Instant.ofEpochSecond(784111777), HttpUtils.parseDate("Sun Nov  6 08:49:37 1994"))
     }
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
@@ -1,0 +1,24 @@
+package at.bitfire.dav4jvm.property
+
+import at.bitfire.dav4jvm.property.push.PushSubscribe
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+class WebPushTest: PropertyTest() {
+
+    @Test
+    fun testPushSubscribe() {
+        val results = parseProperty(
+                "<push-subscribe xmlns=\"DAV:Push\">" +
+                "  <web-push-subscription>\n" +
+                "      <push-resource>https://up.example.net/yohd4yai5Phiz1wi</push-resource>\n" +
+                "  </web-push-subscription>\n" +
+                "  <expires>Wed, 20 Dec 2023 10:03:31 GMT</expires>" +
+                "</push-subscribe>")
+        val result = results.first() as PushSubscribe
+        assertEquals(Instant.ofEpochSecond(1703066611), result.expires)
+        assertEquals("https://up.example.net/yohd4yai5Phiz1wi", result.webPushSubscription?.pushResource)
+    }
+
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
@@ -4,6 +4,7 @@ import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.push.NS_WEBDAV_PUSH
 import at.bitfire.dav4jvm.property.push.PushSubscribe
 import at.bitfire.dav4jvm.property.push.PushTransports
+import at.bitfire.dav4jvm.property.push.Topic
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -28,18 +29,22 @@ class WebPushTest: PropertyTest() {
     }
 
     @Test
-    fun testPushTransports() {
+    fun testServiceDetection() {
         val results = parseProperty(
                 "<push-transports xmlns=\"DAV:Push\">" +
                 "  <transport><something><else/></something></transport>" +
                 "  <transport><web-push/></transport>" +
-                "</push-transports>")
+                "</push-transports>" +
+                "<topic xmlns=\"DAV:Push\">SomeTopic</topic>")
         val result = results.first() as PushTransports
+
         assertEquals(setOf(
             Property.Name(NS_WEBDAV_PUSH, "something"),
             PushTransports.WEB_PUSH
         ), result.transports)
         assertTrue(result.hasWebPush())
+
+        assertEquals("SomeTopic", (results[1] as Topic).topic)
     }
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/property/WebPushTest.kt
@@ -1,7 +1,11 @@
 package at.bitfire.dav4jvm.property
 
+import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.property.push.NS_WEBDAV_PUSH
 import at.bitfire.dav4jvm.property.push.PushSubscribe
+import at.bitfire.dav4jvm.property.push.PushTransports
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 
@@ -10,15 +14,32 @@ class WebPushTest: PropertyTest() {
     @Test
     fun testPushSubscribe() {
         val results = parseProperty(
-                "<push-subscribe xmlns=\"DAV:Push\">" +
-                "  <web-push-subscription>\n" +
-                "      <push-resource>https://up.example.net/yohd4yai5Phiz1wi</push-resource>\n" +
-                "  </web-push-subscription>\n" +
-                "  <expires>Wed, 20 Dec 2023 10:03:31 GMT</expires>" +
-                "</push-subscribe>")
+            "<push-subscribe xmlns=\"DAV:Push\">" +
+            "  <subscription>" +
+            "    <web-push-subscription>\n" +
+            "      <push-resource>https://up.example.net/yohd4yai5Phiz1wi</push-resource>\n" +
+            "    </web-push-subscription>\n" +
+            "  </subscription>" +
+            "  <expires>Wed, 20 Dec 2023 10:03:31 GMT</expires>" +
+            "</push-subscribe>")
         val result = results.first() as PushSubscribe
         assertEquals(Instant.ofEpochSecond(1703066611), result.expires)
-        assertEquals("https://up.example.net/yohd4yai5Phiz1wi", result.webPushSubscription?.pushResource)
+        assertEquals("https://up.example.net/yohd4yai5Phiz1wi", result.subscription?.webPushSubscription?.pushResource)
+    }
+
+    @Test
+    fun testPushTransports() {
+        val results = parseProperty(
+                "<push-transports xmlns=\"DAV:Push\">" +
+                "  <transport><something><else/></something></transport>" +
+                "  <transport><web-push/></transport>" +
+                "</push-transports>")
+        val result = results.first() as PushTransports
+        assertEquals(setOf(
+            Property.Name(NS_WEBDAV_PUSH, "something"),
+            PushTransports.WEB_PUSH
+        ), result.transports)
+        assertTrue(result.hasWebPush())
     }
 
 }


### PR DESCRIPTION
- add properties from WebDAV-Push draft
- `HttpUtils.parseDate` now returns an `Instant` instead of a `ZonedDateTime` because it's expected to be UTC