### PR TITLE
Check URI.equals() for URL equality

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/UrlUtils.kt
@@ -38,6 +38,9 @@ object UrlUtils {
         // drop #fragment parts and convert to URI
         val uri1 = url1.newBuilder().fragment(null).build().toUri()
         val uri2 = url2.newBuilder().fragment(null).build().toUri()
+        if (uri1 == uri2) {
+            return true
+        }
 
         return try {
             val decoded1 = URI(uri1.scheme, uri1.schemeSpecificPart, uri1.fragment)


### PR DESCRIPTION
A server may return a Location header with a differently percentage encoded value, e.g. whether to encode `[` and `]`. `rclone serve webdav` is one server that has this behavior. Since we are already creating URI instances from HttpUrl, we can just compare them to check for this kind of equality.