### PR TITLE
Make all properties data classes

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/Property.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/Property.kt
@@ -7,17 +7,19 @@
 package at.bitfire.dav4jvm
 
 import at.bitfire.dav4jvm.exception.InvalidPropertyException
-import org.xmlpull.v1.XmlPullParser
 import java.io.Serializable
 import java.util.LinkedList
 import java.util.logging.Level
 import java.util.logging.Logger
+import org.xmlpull.v1.XmlPullParser
 
 /**
  * Represents a WebDAV property.
  *
  * Every [Property] must define a static field (use `@JvmStatic`) called `NAME` of type [Property.Name],
  * which will be accessed by reflection.
+ *
+ * Every [Property] must be a data class.
  */
 interface Property {
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/Property.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/Property.kt
@@ -19,7 +19,8 @@ import org.xmlpull.v1.XmlPullParser
  * Every [Property] must define a static field (use `@JvmStatic`) called `NAME` of type [Property.Name],
  * which will be accessed by reflection.
  *
- * Every [Property] must be a data class.
+ * Every [Property] should be a data class in order to be able to compare it against others, and convert to a useful
+ * string for debugging.
  */
 interface Property {
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
@@ -8,13 +8,18 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class CalendarHomeSet: HrefListProperty() {
+data class CalendarHomeSet(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CALDAV, "calendar-home-set")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarHomeSet(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -27,7 +26,7 @@ data class CalendarHomeSet(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, CalendarHomeSet())
+        override fun create(parser: XmlPullParser) = create(parser, ::CalendarHomeSet)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarProxyReadFor(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -25,7 +24,7 @@ data class CalendarProxyReadFor(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, CalendarProxyReadFor())
+        override fun create(parser: XmlPullParser) = create(parser, ::CalendarProxyReadFor)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
@@ -8,9 +8,12 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class CalendarProxyReadFor: HrefListProperty() {
+data class CalendarProxyReadFor(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
         @JvmField

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
@@ -8,9 +8,12 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class CalendarProxyWriteFor: HrefListProperty() {
+data class CalendarProxyWriteFor(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
         @JvmField

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarProxyWriteFor(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -25,7 +24,7 @@ data class CalendarProxyWriteFor(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, CalendarProxyWriteFor())
+        override fun create(parser: XmlPullParser) = create(parser, ::CalendarProxyWriteFor)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarTimezoneId.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarTimezoneId.kt
@@ -11,7 +11,7 @@ import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlReader
 import org.xmlpull.v1.XmlPullParser
 
-class CalendarTimezoneId(
+data class CalendarTimezoneId(
     val identifier: String?
 ): Property {
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarUserAddressSet(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -25,7 +24,7 @@ data class CalendarUserAddressSet(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, CalendarUserAddressSet())
+        override fun create(parser: XmlPullParser) = create(parser, ::CalendarUserAddressSet)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
@@ -8,9 +8,12 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class CalendarUserAddressSet: HrefListProperty() {
+data class CalendarUserAddressSet(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
         @JvmField

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/ScheduleTag.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/ScheduleTag.kt
@@ -13,16 +13,18 @@ import at.bitfire.dav4jvm.XmlReader
 import okhttp3.Response
 import org.xmlpull.v1.XmlPullParser
 
-class ScheduleTag(
-    rawScheduleTag: String?
+data class ScheduleTag(
+    val rawScheduleTag: String?
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CALDAV, "schedule-tag")
 
         fun fromResponse(response: Response) =
                 response.header("Schedule-Tag")?.let { ScheduleTag(it) }
+
     }
 
     /* Value:  opaque-tag

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
@@ -8,13 +8,18 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class Source: HrefListProperty() {
+class Source(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CALENDARSERVER, "source")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 class Source(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -27,7 +26,7 @@ class Source(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, Source())
+        override fun create(parser: XmlPullParser) = create(parser, ::Source)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/SupportedCalendarComponentSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/SupportedCalendarComponentSet.kt
@@ -12,9 +12,9 @@ import at.bitfire.dav4jvm.XmlUtils.propertyName
 import org.xmlpull.v1.XmlPullParser
 
 data class SupportedCalendarComponentSet(
-    var supportsEvents: Boolean,
-    var supportsTasks: Boolean,
-    var supportsJournal: Boolean
+    val supportsEvents: Boolean,
+    val supportsTasks: Boolean,
+    val supportsJournal: Boolean
 ): Property {
 
     companion object {
@@ -37,7 +37,11 @@ data class SupportedCalendarComponentSet(
                <!ELEMENT comp ((allprop | prop*), (allcomp | comp*))>
                <!ATTLIST comp name CDATA #REQUIRED>
             */
-            val components = SupportedCalendarComponentSet(false, false, false)
+            var components = SupportedCalendarComponentSet(
+                supportsEvents = false,
+                supportsTasks = false,
+                supportsJournal = false
+            )
 
             val depth = parser.depth
             var eventType = parser.eventType
@@ -45,15 +49,17 @@ data class SupportedCalendarComponentSet(
                 if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1) {
                     when (parser.propertyName()) {
                         ALLCOMP -> {
-                            components.supportsEvents = true
-                            components.supportsTasks = true
-                            components.supportsJournal = true
+                            components = SupportedCalendarComponentSet(
+                                supportsEvents = true,
+                                supportsTasks = true,
+                                supportsJournal = true
+                            )
                         }
                         COMP ->
                             when (parser.getAttributeValue(null, "name")?.uppercase()) {
-                                "VEVENT" -> components.supportsEvents = true
-                                "VTODO" -> components.supportsTasks = true
-                                "VJOURNAL" -> components.supportsJournal = true
+                                "VEVENT" -> components = components.copy(supportsEvents = true)
+                                "VTODO" -> components = components.copy(supportsTasks = true)
+                                "VJOURNAL" -> components = components.copy(supportsJournal = true)
                             }
                     }
                 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/SupportedCalendarData.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/SupportedCalendarData.kt
@@ -12,7 +12,9 @@ import at.bitfire.dav4jvm.XmlReader
 import okhttp3.MediaType
 import org.xmlpull.v1.XmlPullParser
 
-class SupportedCalendarData: Property {
+data class SupportedCalendarData(
+    val types: Set<MediaType> = emptySet()
+): Property {
 
     companion object {
 
@@ -25,11 +27,7 @@ class SupportedCalendarData: Property {
 
     }
 
-    val types = mutableSetOf<MediaType>()
-
     fun hasJCal() = types.any { "application".equals(it.type, true) && "calendar+json".equals(it.subtype, true) }
-
-    override fun toString() = "[${types.joinToString(", ")}]"
 
 
     object Factory: PropertyFactory {
@@ -37,11 +35,11 @@ class SupportedCalendarData: Property {
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser): SupportedCalendarData {
-            val supported = SupportedCalendarData()
+            val supportedTypes = mutableSetOf<MediaType>()
 
-            XmlReader(parser).readContentTypes(CALENDAR_DATA_TYPE, supported.types::add)
+            XmlReader(parser).readContentTypes(CALENDAR_DATA_TYPE, supportedTypes::add)
 
-            return supported
+            return SupportedCalendarData(supportedTypes)
         }
 
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressData.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressData.kt
@@ -12,16 +12,18 @@ import at.bitfire.dav4jvm.XmlReader
 import org.xmlpull.v1.XmlPullParser
 
 data class AddressData(
-        val card: String?
+    val card: String?
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CARDDAV, "address-data")
 
         // attributes
         const val CONTENT_TYPE = "content-type"
         const val VERSION = "version"
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookDescription.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookDescription.kt
@@ -12,7 +12,7 @@ import at.bitfire.dav4jvm.XmlReader
 import org.xmlpull.v1.XmlPullParser
 
 data class AddressbookDescription(
-    var description: String? = null
+    val description: String? = null
 ): Property {
 
     companion object {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
@@ -8,11 +8,10 @@ package at.bitfire.dav4jvm.property.carddav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 class AddressbookHomeSet(
-    override val hrefs: LinkedList<String> = LinkedList<String>()
+    override val hrefs: List<String> = emptyList()
 ): HrefListProperty(hrefs) {
 
     companion object {
@@ -27,7 +26,7 @@ class AddressbookHomeSet(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, AddressbookHomeSet())
+        override fun create(parser: XmlPullParser) = create(parser, ::AddressbookHomeSet)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
@@ -8,13 +8,18 @@ package at.bitfire.dav4jvm.property.carddav
 
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
-class AddressbookHomeSet: HrefListProperty() {
+class AddressbookHomeSet(
+    override val hrefs: LinkedList<String> = LinkedList<String>()
+): HrefListProperty(hrefs) {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CARDDAV, "addressbook-home-set")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/MaxResourceSize.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/MaxResourceSize.kt
@@ -14,15 +14,21 @@ import org.xmlpull.v1.XmlPullParser
 data class MaxResourceSize(
     val maxSize: Long?
 ) : Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_CARDDAV, "max-resource-size")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) =
             MaxResourceSize(XmlReader(parser).readLong())
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/SupportedAddressData.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/SupportedAddressData.kt
@@ -12,7 +12,9 @@ import at.bitfire.dav4jvm.XmlReader
 import okhttp3.MediaType
 import org.xmlpull.v1.XmlPullParser
 
-class SupportedAddressData: Property {
+class SupportedAddressData(
+    val types: Set<MediaType> = emptySet()
+): Property {
 
     companion object {
 
@@ -25,8 +27,6 @@ class SupportedAddressData: Property {
 
     }
 
-    val types = mutableSetOf<MediaType>()
-
     fun hasVCard4() = types.any { "text/vcard; version=4.0".equals(it.toString(), true) }
     fun hasJCard() = types.any { "application".equals(it.type, true) && "vcard+json".equals(it.subtype, true) }
 
@@ -38,11 +38,11 @@ class SupportedAddressData: Property {
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser): SupportedAddressData {
-            val supported = SupportedAddressData()
+            val supportedTypes = mutableSetOf<MediaType>()
 
-            XmlReader(parser).readContentTypes(ADDRESS_DATA_TYPE, supported.types::add)
+            XmlReader(parser).readContentTypes(ADDRESS_DATA_TYPE, supportedTypes::add)
 
-            return supported
+            return SupportedAddressData(supportedTypes)
         }
 
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/AddMember.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/AddMember.kt
@@ -18,14 +18,20 @@ import org.xmlpull.v1.XmlPullParser
 data class AddMember(
     val href: String?
 ): Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "add-member")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) = AddMember(XmlReader(parser).readTextProperty(DavResource.HREF))
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CreationDate.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CreationDate.kt
@@ -14,15 +14,21 @@ import org.xmlpull.v1.XmlPullParser
 data class CreationDate(
     var creationDate: String?
 ): Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "creationdate")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) =
             CreationDate(XmlReader(parser).readText())
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrincipal.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrincipal.kt
@@ -19,8 +19,10 @@ data class CurrentUserPrincipal(
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "current-user-principal")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
@@ -15,11 +15,11 @@ import org.xmlpull.v1.XmlPullParser
 data class CurrentUserPrivilegeSet(
     // not all privileges from RFC 3744 are implemented by now
     // feel free to add more if you need them for your project
-    var mayRead: Boolean = false,
-    var mayWriteProperties: Boolean = false,
-    var mayWriteContent: Boolean = false,
-    var mayBind: Boolean = false,
-    var mayUnbind: Boolean = false
+    val mayRead: Boolean = false,
+    val mayWriteProperties: Boolean = false,
+    val mayWriteContent: Boolean = false,
+    val mayBind: Boolean = false,
+    val mayUnbind: Boolean = false
 ): Property {
 
     companion object {
@@ -46,7 +46,7 @@ data class CurrentUserPrivilegeSet(
         override fun create(parser: XmlPullParser): CurrentUserPrivilegeSet {
             // <!ELEMENT current-user-privilege-set (privilege*)>
             // <!ELEMENT privilege ANY>
-            val privs = CurrentUserPrivilegeSet()
+            var privs = CurrentUserPrivilegeSet()
 
             XmlReader(parser).processTag(PRIVILEGE) {
                 val depth = parser.depth
@@ -55,27 +55,27 @@ data class CurrentUserPrivilegeSet(
                     if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
                         when (parser.propertyName()) {
                             READ ->
-                                privs.mayRead = true
+                                privs = privs.copy(mayRead = true)
                             WRITE -> {
-                                privs.mayBind = true
-                                privs.mayUnbind = true
-                                privs.mayWriteProperties = true
-                                privs.mayWriteContent = true
+                                privs = privs.copy(mayBind = true)
+                                privs = privs.copy(mayUnbind = true)
+                                privs = privs.copy(mayWriteProperties = true)
+                                privs = privs.copy(mayWriteContent = true)
                             }
                             WRITE_PROPERTIES ->
-                                privs.mayWriteProperties = true
+                                privs = privs.copy(mayWriteProperties = true)
                             WRITE_CONTENT ->
-                                privs.mayWriteContent = true
+                                privs = privs.copy(mayWriteContent = true)
                             BIND ->
-                                privs.mayBind = true
+                                privs = privs.copy(mayBind = true)
                             UNBIND ->
-                                privs.mayUnbind = true
+                                privs = privs.copy(mayUnbind = true)
                             ALL -> {
-                                privs.mayRead = true
-                                privs.mayBind = true
-                                privs.mayUnbind = true
-                                privs.mayWriteProperties = true
-                                privs.mayWriteContent = true
+                                privs = privs.copy(mayRead = true)
+                                privs = privs.copy(mayBind = true)
+                                privs = privs.copy(mayUnbind = true)
+                                privs = privs.copy(mayWriteProperties = true)
+                                privs = privs.copy(mayWriteContent = true)
                             }
                         }
                     eventType = parser.next()
@@ -84,5 +84,7 @@ data class CurrentUserPrivilegeSet(
 
             return privs
         }
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/CurrentUserPrivilegeSet.kt
@@ -57,10 +57,12 @@ data class CurrentUserPrivilegeSet(
                             READ ->
                                 privs = privs.copy(mayRead = true)
                             WRITE -> {
-                                privs = privs.copy(mayBind = true)
-                                privs = privs.copy(mayUnbind = true)
-                                privs = privs.copy(mayWriteProperties = true)
-                                privs = privs.copy(mayWriteContent = true)
+                                privs = privs.copy(
+                                    mayBind = true,
+                                    mayUnbind = true,
+                                    mayWriteProperties = true,
+                                    mayWriteContent = true
+                                )
                             }
                             WRITE_PROPERTIES ->
                                 privs = privs.copy(mayWriteProperties = true)
@@ -71,11 +73,13 @@ data class CurrentUserPrivilegeSet(
                             UNBIND ->
                                 privs = privs.copy(mayUnbind = true)
                             ALL -> {
-                                privs = privs.copy(mayRead = true)
-                                privs = privs.copy(mayBind = true)
-                                privs = privs.copy(mayUnbind = true)
-                                privs = privs.copy(mayWriteProperties = true)
-                                privs = privs.copy(mayWriteContent = true)
+                                privs = privs.copy(
+                                    mayRead = true,
+                                    mayBind = true,
+                                    mayUnbind = true,
+                                    mayWriteProperties = true,
+                                    mayWriteContent = true
+                                )
                             }
                         }
                     eventType = parser.next()

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/DisplayName.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/DisplayName.kt
@@ -16,8 +16,10 @@ data class DisplayName(
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "displayname")
+
     }
 
 
@@ -30,4 +32,5 @@ data class DisplayName(
             DisplayName(XmlReader(parser).readText())
 
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetContentLength.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetContentLength.kt
@@ -14,15 +14,21 @@ import org.xmlpull.v1.XmlPullParser
 data class GetContentLength(
     val contentLength: Long?
 ) : Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "getcontentlength")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) =
             GetContentLength(XmlReader(parser).readLong())
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetContentType.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetContentType.kt
@@ -18,8 +18,10 @@ data class GetContentType(
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "getcontenttype")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetETag.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetETag.kt
@@ -19,8 +19,8 @@ import org.xmlpull.v1.XmlPullParser
  * Can also be used to parse ETags from HTTP responses – just pass the raw ETag
  * header value to the constructor and then use [eTag] and [weak].
  */
-class GetETag(
-    rawETag: String?
+data class GetETag(
+    val rawETag: String?
 ): Property {
 
     companion object {
@@ -64,8 +64,6 @@ class GetETag(
             weak = false
         }
     }
-
-    override fun toString() = "ETag(weak=${weak}, tag=$eTag)"
 
     override fun equals(other: Any?): Boolean {
         if (other !is GetETag)

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetLastModified.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GetLastModified.kt
@@ -9,16 +9,18 @@ package at.bitfire.dav4jvm.property.webdav
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlReader
-import org.xmlpull.v1.XmlPullParser
 import java.time.Instant
+import org.xmlpull.v1.XmlPullParser
 
 data class GetLastModified(
-    var lastModified: Instant?
+    val lastModified: Instant?
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "getlastmodified")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
@@ -9,7 +9,9 @@ package at.bitfire.dav4jvm.property.webdav
 import at.bitfire.dav4jvm.Property
 import org.xmlpull.v1.XmlPullParser
 
-class GroupMembership: HrefListProperty(emptyList()) {
+class GroupMembership(
+    override val hrefs: List<String>
+): HrefListProperty(hrefs) {
 
     companion object {
 
@@ -23,7 +25,7 @@ class GroupMembership: HrefListProperty(emptyList()) {
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser) { GroupMembership() }
+        override fun create(parser: XmlPullParser) = create(parser, ::GroupMembership)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
@@ -12,8 +12,10 @@ import org.xmlpull.v1.XmlPullParser
 class GroupMembership: HrefListProperty() {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "group-membership")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
@@ -9,7 +9,7 @@ package at.bitfire.dav4jvm.property.webdav
 import at.bitfire.dav4jvm.Property
 import org.xmlpull.v1.XmlPullParser
 
-class GroupMembership: HrefListProperty() {
+class GroupMembership: HrefListProperty(emptyList()) {
 
     companion object {
 
@@ -23,7 +23,7 @@ class GroupMembership: HrefListProperty() {
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, GroupMembership())
+        override fun create(parser: XmlPullParser) = create(parser) { GroupMembership() }
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/HrefListProperty.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/HrefListProperty.kt
@@ -10,17 +10,19 @@ import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlReader
+import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
-import java.util.*
 
-abstract class HrefListProperty: Property {
+/**
+ * Represents a list of hrefs.
+ *
+ * Every [HrefListProperty] must be a data class.
+ */
+abstract class HrefListProperty(
+    open val hrefs: LinkedList<String> = LinkedList<String>()
+): Property {
 
-    val hrefs = LinkedList<String>()
-
-    val href
-        get() = hrefs.firstOrNull()
-
-    override fun toString() =  "href=[" + hrefs.joinToString(", ") + "]"
+    val href get() = hrefs.firstOrNull()
 
 
     abstract class Factory : PropertyFactory {

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/HrefListProperty.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/HrefListProperty.kt
@@ -10,7 +10,6 @@ import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlReader
-import java.util.LinkedList
 import org.xmlpull.v1.XmlPullParser
 
 /**
@@ -19,7 +18,7 @@ import org.xmlpull.v1.XmlPullParser
  * Every [HrefListProperty] must be a data class.
  */
 abstract class HrefListProperty(
-    open val hrefs: LinkedList<String> = LinkedList<String>()
+    open val hrefs: List<String>
 ): Property {
 
     val href get() = hrefs.firstOrNull()
@@ -27,9 +26,20 @@ abstract class HrefListProperty(
 
     abstract class Factory : PropertyFactory {
 
+        @Deprecated("hrefs is no longer mutable.", level = DeprecationLevel.ERROR)
         fun create(parser: XmlPullParser, list: HrefListProperty): HrefListProperty {
-            XmlReader(parser).readTextPropertyList(DavResource.HREF, list.hrefs)
+            val hrefs = list.hrefs.toMutableList()
+            XmlReader(parser).readTextPropertyList(DavResource.HREF, hrefs)
             return list
+        }
+
+        fun <PropertyType> create(
+            parser: XmlPullParser,
+            constructor: (hrefs: List<String>
+                ) -> PropertyType): PropertyType {
+            val hrefs = mutableListOf<String>()
+            XmlReader(parser).readTextPropertyList(DavResource.HREF, hrefs)
+            return constructor(hrefs)
         }
 
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
@@ -12,8 +12,10 @@ import org.xmlpull.v1.XmlPullParser
 class Owner: HrefListProperty() {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "owner")
+
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
@@ -9,7 +9,9 @@ package at.bitfire.dav4jvm.property.webdav
 import at.bitfire.dav4jvm.Property
 import org.xmlpull.v1.XmlPullParser
 
-class Owner: HrefListProperty(emptyList()) {
+data class Owner(
+    override val hrefs: List<String>
+): HrefListProperty(hrefs) {
 
     companion object {
 
@@ -23,7 +25,7 @@ class Owner: HrefListProperty(emptyList()) {
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser) { Owner() }
+        override fun create(parser: XmlPullParser) = create(parser, ::Owner)
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
@@ -9,7 +9,7 @@ package at.bitfire.dav4jvm.property.webdav
 import at.bitfire.dav4jvm.Property
 import org.xmlpull.v1.XmlPullParser
 
-class Owner: HrefListProperty() {
+class Owner: HrefListProperty(emptyList()) {
 
     companion object {
 
@@ -23,7 +23,7 @@ class Owner: HrefListProperty() {
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, Owner())
+        override fun create(parser: XmlPullParser) = create(parser) { Owner() }
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/QuotaAvailableBytes.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/QuotaAvailableBytes.kt
@@ -14,15 +14,21 @@ import org.xmlpull.v1.XmlPullParser
 data class QuotaAvailableBytes(
     val quotaAvailableBytes: Long?
 ) : Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "quota-available-bytes")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) =
             QuotaAvailableBytes(XmlReader(parser).readLong())
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/QuotaUsedBytes.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/QuotaUsedBytes.kt
@@ -14,15 +14,21 @@ import org.xmlpull.v1.XmlPullParser
 data class QuotaUsedBytes(
     val quotaUsedBytes: Long?
 ) : Property {
+
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "quota-used-bytes")
+
     }
 
     object Factory: PropertyFactory {
+
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser) =
             QuotaUsedBytes(XmlReader(parser).readLong())
+
     }
+
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/ResourceType.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/ResourceType.kt
@@ -13,9 +13,12 @@ import at.bitfire.dav4jvm.property.caldav.NS_CALENDARSERVER
 import at.bitfire.dav4jvm.property.carddav.NS_CARDDAV
 import org.xmlpull.v1.XmlPullParser
 
-class ResourceType: Property {
+class ResourceType(
+    val types: Set<Property.Name> = emptySet()
+): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "resourcetype")
 
@@ -28,11 +31,8 @@ class ResourceType: Property {
         val CALENDAR_PROXY_READ = Property.Name(NS_CALENDARSERVER, "calendar-proxy-read")      // CalDAV Proxy
         val CALENDAR_PROXY_WRITE = Property.Name(NS_CALENDARSERVER, "calendar-proxy-write")    // CalDAV Proxy
         val SUBSCRIBED = Property.Name(NS_CALENDARSERVER, "subscribed")
+
     }
-
-    val types = mutableSetOf<Property.Name>()
-
-    override fun toString() = "[${types.joinToString(", ")}]"
 
 
     object Factory: PropertyFactory {
@@ -40,7 +40,7 @@ class ResourceType: Property {
         override fun getName() = NAME
 
         override fun create(parser: XmlPullParser): ResourceType {
-            val type = ResourceType()
+            val types = mutableSetOf<Property.Name>()
 
             val depth = parser.depth
             var eventType = parser.eventType
@@ -57,13 +57,13 @@ class ResourceType: Property {
                         CALENDAR_PROXY_WRITE -> typeName = CALENDAR_PROXY_WRITE
                         SUBSCRIBED -> typeName = SUBSCRIBED
                     }
-                    type.types.add(typeName)
+                    types.add(typeName)
                 }
                 eventType = parser.next()
             }
             assert(parser.depth == depth)
 
-            return type
+            return ResourceType(types)
         }
 
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/SupportedReportSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/SupportedReportSet.kt
@@ -11,7 +11,9 @@ import at.bitfire.dav4jvm.PropertyFactory
 import at.bitfire.dav4jvm.XmlReader
 import org.xmlpull.v1.XmlPullParser
 
-class SupportedReportSet: Property {
+data class SupportedReportSet(
+    val reports: Set<String> = emptySet()
+): Property {
 
     companion object {
 
@@ -25,10 +27,6 @@ class SupportedReportSet: Property {
 
     }
 
-    val reports = mutableSetOf<String>()
-
-    override fun toString() = "[${reports.joinToString(", ")}]"
-
 
     object Factory: PropertyFactory {
 
@@ -40,17 +38,17 @@ class SupportedReportSet: Property {
                <!ELEMENT report ANY>
             */
 
-            val supported = SupportedReportSet()
+            val reports = mutableSetOf<String>()
             XmlReader(parser).processTag(SUPPORTED_REPORT) {
                 processTag(REPORT) {
                     parser.nextTag()
                     if (parser.eventType == XmlPullParser.TEXT)
-                        supported.reports += parser.text
+                        reports += parser.text
                     else if (parser.eventType == XmlPullParser.START_TAG)
-                        supported.reports += "${parser.namespace}${parser.name}"
+                        reports += "${parser.namespace}${parser.name}"
                 }
             }
-            return supported
+            return SupportedReportSet(reports)
         }
 
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/SyncToken.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/SyncToken.kt
@@ -16,8 +16,10 @@ data class SyncToken(
 ): Property {
 
     companion object {
+
         @JvmField
         val NAME = Property.Name(NS_WEBDAV, "sync-token")
+
     }
 
 
@@ -30,4 +32,5 @@ data class SyncToken(
             SyncToken(XmlReader(parser).readText())
 
     }
+
 }


### PR DESCRIPTION
### Changes
- Got rid of `HrefListProperty$toString`: should be handled by the data class.
- Got rid of `GetETag$toString`: should be handled by the data class.
- Got rid of `ResourceType$toString`: should be handled by the data class.
- Moved `HrefListProperty.hrefs` to the constructor and made open so all the child classes can override it.
- Improved formatting of some files.

### FIXME
- `ScheduleTag` has a custom `toString` method, do we want that implementation or use the data class one?
- I've made all the classes use `val` instead of `var`. I think it's the best approach, since the classes shouldn't be mutable, they represent an state given by the server, and it should be kept like that. We are only modifying the values for constructing the class, and I think it's not correct to keep them as  `vars`.
- All `HrefListProperty` classes use `LinkedList`. Following the same principle as the point before, I think they should be immutable lists.