### PR TITLE
Use HrefList only for multiple hrefs

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/UrlUtils.kt
@@ -16,9 +16,6 @@ import okhttp3.HttpUrl
 
 object UrlUtils {
 
-    @Deprecated("Use equalsForWebDAV instead", ReplaceWith("url1.equalsForWebDAV(url2)"))
-    fun equals(url1: HttpUrl, url2: HttpUrl) = url1.equalsForWebDAV(url2)
-
     /**
      * Gets the first-level domain name (without subdomains) from a host name.
      * Also removes trailing dots.

--- a/src/main/kotlin/at/bitfire/dav4jvm/XmlReader.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/XmlReader.kt
@@ -90,7 +90,7 @@ class XmlReader(
         val depth = parser.depth
         var eventType = parser.eventType
         while (!((eventType == XmlPullParser.END_TAG || eventType == XmlPullParser.END_DOCUMENT) && parser.depth == depth)) {
-            if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1 && parser.propertyName() == name)
+            if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1 && parser.propertyName() == name && result == null)
                 result = parser.nextText()
             eventType = parser.next()
         }

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarHomeSet.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarHomeSet(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyReadFor.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarProxyReadFor(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarProxyWriteFor.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarProxyWriteFor(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/CalendarUserAddressSet.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 data class CalendarUserAddressSet(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/caldav/Source.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.caldav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 class Source(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/carddav/AddressbookHomeSet.kt
@@ -11,7 +11,7 @@
 package at.bitfire.dav4jvm.property.carddav
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.property.webdav.HrefListProperty
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 class AddressbookHomeSet(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/common/HrefListProperty.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/common/HrefListProperty.kt
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-package at.bitfire.dav4jvm.property.webdav
+package at.bitfire.dav4jvm.property.common
 
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.Property
@@ -25,15 +25,12 @@ abstract class HrefListProperty(
     open val hrefs: List<String>
 ): Property {
 
-    val href get() = hrefs.firstOrNull()
-
-
     abstract class Factory : PropertyFactory {
 
         @Deprecated("hrefs is no longer mutable.", level = DeprecationLevel.ERROR)
         fun create(parser: XmlPullParser, list: HrefListProperty): HrefListProperty {
             val hrefs = list.hrefs.toMutableList()
-            XmlReader(parser).readTextPropertyList(DavResource.HREF, hrefs)
+            XmlReader(parser).readTextPropertyList(DavResource.Companion.HREF, hrefs)
             return list
         }
 
@@ -42,7 +39,7 @@ abstract class HrefListProperty(
             constructor: (hrefs: List<String>
                 ) -> PropertyType): PropertyType {
             val hrefs = mutableListOf<String>()
-            XmlReader(parser).readTextPropertyList(DavResource.HREF, hrefs)
+            XmlReader(parser).readTextPropertyList(DavResource.Companion.HREF, hrefs)
             return constructor(hrefs)
         }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/GroupMembership.kt
@@ -11,6 +11,7 @@
 package at.bitfire.dav4jvm.property.webdav
 
 import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 class GroupMembership(

--- a/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/property/webdav/Owner.kt
@@ -10,12 +10,15 @@
 
 package at.bitfire.dav4jvm.property.webdav
 
+import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.Property
+import at.bitfire.dav4jvm.XmlReader
+import at.bitfire.dav4jvm.property.common.HrefListProperty
 import org.xmlpull.v1.XmlPullParser
 
 data class Owner(
-    override val hrefs: List<String>
-): HrefListProperty(hrefs) {
+    val href: String?
+): Property {
 
     companion object {
 
@@ -29,7 +32,8 @@ data class Owner(
 
         override fun getName() = NAME
 
-        override fun create(parser: XmlPullParser) = create(parser, ::Owner)
+        override fun create(parser: XmlPullParser): Owner =
+            Owner(XmlReader(parser).readTextProperty(DavResource.Companion.HREF))
 
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/property/OwnerTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/property/OwnerTest.kt
@@ -13,9 +13,16 @@ package at.bitfire.dav4jvm.property
 import at.bitfire.dav4jvm.property.webdav.Owner
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class OwnerTest: PropertyTest() {
+
+    @Test
+    fun testOwner_Empty() {
+        val results = parseProperty("<owner></owner>")
+        assertTrue(results.isEmpty())
+    }
 
     @Test
     fun testOwner_PlainText() {
@@ -36,6 +43,22 @@ class OwnerTest: PropertyTest() {
         val results = parseProperty("<owner xmlns=\"DAV:\"><href>https://example.com</href></owner>")
         val owner = results.first() as Owner
         assertEquals("https://example.com", owner.href)
+    }
+
+    @Test
+    fun testOwner_TwoHrefs() {
+        val results = parseProperty("<owner xmlns=\"DAV:\">" +
+                "<href>https://example.com/owner1</href>" +
+                "<href>https://example.com/owner2</href>" +
+                "</owner>")
+        val owner = results.first() as Owner
+        assertEquals("https://example.com/owner1", owner.href)
+    }
+
+    @Test
+    fun testOwner_WithoutHref() {
+        val results = parseProperty("<owner>invalid</owner>")
+        assertTrue(results.isEmpty())
     }
 
 }


### PR DESCRIPTION
- Owner [allows only one href](https://www.rfc-editor.org/rfc/rfc3744#section-5.1)
- HrefListProperty: remove shortcut to get first value because all values should be processed (shortcut encourages unclean processing)
- remove deprecated `UrlUtils.equals()`