### PR TITLE
Move Response extraction logic out of init of `DavException`

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/DavResource.kt
@@ -739,7 +739,7 @@ open class DavResource @JvmOverloads constructor(
      */
     fun assertMultiStatus(response: Response) {
         if (response.code != HTTP_MULTISTATUS)
-            throw DavException("Expected 207 Multi-Status, got ${response.code} ${response.message}", httpResponse = response)
+            throw DavException("Expected 207 Multi-Status, got ${response.code} ${response.message}").populateHttpResponse(response)
 
         response.peekBody(XML_SIGNATURE.size.toLong()).use { body ->
             body.contentType()?.let { mimeType ->
@@ -760,7 +760,7 @@ open class DavResource @JvmOverloads constructor(
                         logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
                     }
 
-                    throw DavException("Received non-XML 207 Multi-Status", httpResponse = response)
+                    throw DavException("Received non-XML 207 Multi-Status").populateHttpResponse(response)
                 }
             } ?: logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
         }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/ConflictException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/ConflictException.kt
@@ -15,7 +15,10 @@ import java.net.HttpURLConnection
 
 class ConflictException: HttpException {
 
-    constructor(response: Response): super(response)
+    companion object: DavExceptionCompanion<ConflictException> {
+        override fun constructor(message: String?): ConflictException = ConflictException(message)
+    }
+
     constructor(message: String?): super(HttpURLConnection.HTTP_CONFLICT, message)
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
@@ -45,6 +45,10 @@ open class DavException @JvmOverloads constructor(
             type.type == "text" ||
                     (type.type == "application" && type.subtype in arrayOf("html", "xml"))
 
+        fun fromHttpResponse(message: String, ex: Throwable? = null, httpResponse: Response?): DavException {
+            return DavException(message, ex).apply { populateHttpResponse(httpResponse) }
+        }
+
     }
 
     private val logger
@@ -77,20 +81,11 @@ open class DavException @JvmOverloads constructor(
         private set
 
     /**
-     * Initializes the [DavException] and populates [request], [requestBody], [response], [responseBody] and [errors] with the contents of [httpResponse].
-     *
-     * The whole response body may be loaded, so this function should be called in blocking-sensitive contexts.
-     */
-    constructor(message: String, httpResponse: Response?, ex: Throwable? = null): this(message, ex) {
-        populateHttpResponse(httpResponse)
-    }
-
-    /**
      * Fills [request], [requestBody], [response], [responseBody] and [errors] according to the given [httpResponse].
      *
      * The whole response body may be loaded, so this function should be called in blocking-sensitive contexts.
      */
-    private fun populateHttpResponse(httpResponse: Response?): DavException {
+    fun populateHttpResponse(httpResponse: Response?) {
         if (httpResponse != null) {
             response = httpResponse.toString()
 
@@ -153,8 +148,6 @@ open class DavException @JvmOverloads constructor(
         } else {
             response = null
         }
-
-        return this
     }
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
@@ -76,8 +76,21 @@ open class DavException @JvmOverloads constructor(
     var errors: List<Error> = listOf()
         private set
 
+    /**
+     * Initializes the [DavException] and populates [request], [requestBody], [response], [responseBody] and [errors] with the contents of [httpResponse].
+     *
+     * The whole response body may be loaded, so this function should be called in blocking-sensitive contexts.
+     */
+    constructor(message: String, httpResponse: Response?, ex: Throwable? = null): this(message, ex) {
+        populateHttpResponse(httpResponse)
+    }
 
-    fun populateHttpResponse(httpResponse: Response?): DavException {
+    /**
+     * Fills [request], [requestBody], [response], [responseBody] and [errors] according to the given [httpResponse].
+     *
+     * The whole response body may be loaded, so this function should be called in blocking-sensitive contexts.
+     */
+    private fun populateHttpResponse(httpResponse: Response?): DavException {
         if (httpResponse != null) {
             response = httpResponse.toString()
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/DavExceptionCompanion.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/DavExceptionCompanion.kt
@@ -11,14 +11,13 @@
 package at.bitfire.dav4jvm.exception
 
 import okhttp3.Response
-import java.net.HttpURLConnection
 
-class ForbiddenException: HttpException {
+interface DavExceptionCompanion<CL: DavException> {
+    fun constructor(message: String?): CL
 
-    companion object: DavExceptionCompanion<ForbiddenException> {
-        override fun constructor(message: String?): ForbiddenException = ForbiddenException(message)
+    fun fromHttpResponse(httpResponse: Response): CL {
+        return constructor(httpResponse.message).apply { populateHttpResponse(httpResponse) }
     }
 
-    constructor(message: String?): super(HttpURLConnection.HTTP_FORBIDDEN, message)
-
+    fun fromMessage(message: String?): CL = constructor(message)
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/GoneException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/GoneException.kt
@@ -15,7 +15,10 @@ import java.net.HttpURLConnection
 
 class GoneException: HttpException {
 
-    constructor(response: Response): super(response)
+    companion object: DavExceptionCompanion<GoneException> {
+        override fun constructor(message: String?): GoneException = GoneException(message)
+    }
+
     constructor(message: String?): super(HttpURLConnection.HTTP_GONE, message)
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -17,14 +17,15 @@ import okhttp3.Response
  */
 open class HttpException: DavException {
 
-    var code: Int
+    companion object: DavExceptionCompanion<HttpException> {
+        override fun constructor(message: String?): HttpException = HttpException(-1, message)
 
-    constructor(response: Response): super(
-        "HTTP ${response.code} ${response.message}",
-        httpResponse = response
-    ) {
-        code = response.code
+        override fun fromHttpResponse(httpResponse: Response): HttpException {
+            return HttpException(httpResponse.code, httpResponse.message).apply { populateHttpResponse(httpResponse) }
+        }
     }
+
+    var code: Int
 
     constructor(code: Int, message: String?): super("HTTP $code $message") {
         this.code = code

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -20,10 +20,10 @@ open class HttpException: DavException {
     var code: Int
 
     constructor(response: Response): super(
-            "HTTP ${response.code} ${response.message}",
-            httpResponse = response
+            "HTTP ${response.code} ${response.message}"
     ) {
         code = response.code
+        populateHttpResponse(response)
     }
 
     constructor(code: Int, message: String?): super("HTTP $code $message") {

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -20,10 +20,10 @@ open class HttpException: DavException {
     var code: Int
 
     constructor(response: Response): super(
-            "HTTP ${response.code} ${response.message}"
+        "HTTP ${response.code} ${response.message}",
+        httpResponse = response
     ) {
         code = response.code
-        populateHttpResponse(response)
     }
 
     constructor(code: Int, message: String?): super("HTTP $code $message") {

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/NotFoundException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/NotFoundException.kt
@@ -15,7 +15,10 @@ import java.net.HttpURLConnection
 
 class NotFoundException: HttpException {
 
-    constructor(response: Response): super(response)
+    companion object: DavExceptionCompanion<NotFoundException> {
+        override fun constructor(message: String?): NotFoundException = NotFoundException(message)
+    }
+
     constructor(message: String?): super(HttpURLConnection.HTTP_NOT_FOUND, message)
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/PreconditionFailedException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/PreconditionFailedException.kt
@@ -15,7 +15,10 @@ import java.net.HttpURLConnection
 
 class PreconditionFailedException: HttpException {
 
-    constructor(response: Response): super(response)
+    companion object: DavExceptionCompanion<PreconditionFailedException> {
+        override fun constructor(message: String?): PreconditionFailedException = PreconditionFailedException(message)
+    }
+
     constructor(message: String?): super(HttpURLConnection.HTTP_PRECON_FAILED, message)
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableException.kt
@@ -22,33 +22,10 @@ import java.util.logging.Logger
 
 class ServiceUnavailableException : HttpException {
 
-    private val logger
-        get() = Logger.getLogger(javaClass.name)
-
     val retryAfter: Instant?
 
-    constructor(message: String?) : super(HttpURLConnection.HTTP_UNAVAILABLE, message) {
-        retryAfter = null
-    }
-
-    constructor(response: Response) : super(response) {
-        // Retry-After  = "Retry-After" ":" ( HTTP-date | delta-seconds )
-        // HTTP-date    = rfc1123-date | rfc850-date | asctime-date
-
-        var retryAfterValue: Instant? = null
-        response.header("Retry-After")?.let { after ->
-            retryAfterValue = HttpUtils.parseDate(after) ?:
-                // not a HTTP-date, must be delta-seconds
-                try {
-                    val seconds = after.toLong()
-                    Instant.now().plusSeconds(seconds)
-                } catch (e: NumberFormatException) {
-                    logger.log(Level.WARNING, "Received Retry-After which was not a HTTP-date nor delta-seconds: $after", e)
-                    null
-                }
-        }
-
-        retryAfter = retryAfterValue
+    constructor(message: String?, retryAfter: Instant? = null) : super(HttpURLConnection.HTTP_UNAVAILABLE, message) {
+        this.retryAfter = retryAfter
     }
 
 
@@ -75,12 +52,37 @@ class ServiceUnavailableException : HttpException {
     }
 
 
-    companion object {
+    companion object: DavExceptionCompanion<ServiceUnavailableException> {
 
         // default values for getDelayUntil
         const val DELAY_UNTIL_DEFAULT = 15 * 60L    // 15 min
         const val DELAY_UNTIL_MIN = 1 * 60L         // 1 min
         const val DELAY_UNTIL_MAX = 2 * 60 * 60L    // 2 hours
+
+        private val logger
+            get() = Logger.getLogger(this::javaClass.name)
+
+        override fun constructor(message: String?): ServiceUnavailableException = ServiceUnavailableException(message)
+
+        override fun fromHttpResponse(httpResponse: Response): ServiceUnavailableException = ServiceUnavailableException(
+            message = httpResponse.message,
+            retryAfter = httpResponse.let { response ->
+                // Retry-After  = "Retry-After" ":" ( HTTP-date | delta-seconds )
+                // HTTP-date    = rfc1123-date | rfc850-date | asctime-date
+
+                response.header("Retry-After")?.let { after ->
+                    HttpUtils.parseDate(after) ?:
+                    // not a HTTP-date, must be delta-seconds
+                    try {
+                        val seconds = after.toLong()
+                        Instant.now().plusSeconds(seconds)
+                    } catch (e: NumberFormatException) {
+                        logger.log(Level.WARNING, "Received Retry-After which was not a HTTP-date nor delta-seconds: $after", e)
+                        null
+                    }
+                }
+            }
+        )
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/UnauthorizedException.kt
@@ -15,7 +15,10 @@ import java.net.HttpURLConnection
 
 class UnauthorizedException: HttpException {
 
-    constructor(response: Response): super(response)
+    companion object: DavExceptionCompanion<UnauthorizedException> {
+        override fun constructor(message: String?): UnauthorizedException = UnauthorizedException(message)
+    }
+
     constructor(message: String?): super(HttpURLConnection.HTTP_UNAUTHORIZED, message)
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
@@ -58,15 +58,18 @@ class DavExceptionTest {
         builder.append(CharArray(DavException.MAX_EXCERPT_SIZE+100) { '*' })
         val body = builder.toString()
 
-        val e = DavException("Error with large request body", null, Response.Builder()
-            .request(Request.Builder()
-                .url("http://example.com")
-                .post(body.toRequestBody("text/plain".toMediaType()))
-                .build())
-            .protocol(Protocol.HTTP_1_1)
-            .code(204)
-            .message("No Content")
-            .build())
+        val e = DavException("Error with large request body", null)
+            .populateHttpResponse(
+                Response.Builder()
+                    .request(Request.Builder()
+                        .url("http://example.com")
+                        .post(body.toRequestBody("text/plain".toMediaType()))
+                        .build())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(204)
+                    .message("No Content")
+                    .build()
+            )
 
         assertTrue(e.errors.isEmpty())
         assertEquals(

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
@@ -58,18 +58,19 @@ class DavExceptionTest {
         builder.append(CharArray(DavException.MAX_EXCERPT_SIZE+100) { '*' })
         val body = builder.toString()
 
-        val e = DavException("Error with large request body", null)
-            .populateHttpResponse(
-                Response.Builder()
-                    .request(Request.Builder()
-                        .url("http://example.com")
-                        .post(body.toRequestBody("text/plain".toMediaType()))
-                        .build())
-                    .protocol(Protocol.HTTP_1_1)
-                    .code(204)
-                    .message("No Content")
-                    .build()
-            )
+        val e = DavException.fromHttpResponse(
+            "Error with large request body",
+            null,
+            Response.Builder()
+                .request(Request.Builder()
+                    .url("http://example.com")
+                    .post(body.toRequestBody("text/plain".toMediaType()))
+                    .build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(204)
+                .message("No Content")
+                .build()
+        )
 
         assertTrue(e.errors.isEmpty())
         assertEquals(

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpExceptionTest.kt
@@ -37,7 +37,7 @@ class HttpExceptionTest {
                 .message(responseMessage)
                 .body("SERVER\r\nRESPONSE".toResponseBody("text/something-other".toMediaType()))
                 .build()
-        val e = HttpException(response)
+        val e = HttpException.fromHttpResponse(response)
         assertTrue(e.message!!.contains("500"))
         assertTrue(e.message!!.contains(responseMessage))
         assertTrue(e.requestBody!!.contains("REQUEST\nBODY"))

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableExceptionTest.kt
@@ -33,7 +33,7 @@ class ServiceUnavailableExceptionTest {
 
     @Test
     fun testRetryAfter_NoTime() {
-        val e = ServiceUnavailableException(response503)
+        val e = ServiceUnavailableException.fromHttpResponse(response503)
         assertNull(e.retryAfter)
     }
 
@@ -42,7 +42,7 @@ class ServiceUnavailableExceptionTest {
         val response = response503.newBuilder()
                 .header("Retry-After", "120")
                 .build()
-        val e = ServiceUnavailableException(response)
+        val e = ServiceUnavailableException.fromHttpResponse(response)
         assertNotNull(e.retryAfter)
         assertTrue(withinTimeRange(e.retryAfter!!, 120))
     }
@@ -53,7 +53,7 @@ class ServiceUnavailableExceptionTest {
         val response = response503.newBuilder()
                 .header("Retry-After", HttpUtils.formatDate(after30min))
                 .build()
-        val e = ServiceUnavailableException(response)
+        val e = ServiceUnavailableException.fromHttpResponse(response)
         assertNotNull(e.retryAfter)
         assertTrue(withinTimeRange(e.retryAfter!!, 30*60))
     }


### PR DESCRIPTION
Moved all the code inside of `init` in `DavException` to its own function to initialize the contents, decoupling a bit better how the data is instantiated.

---

Depends on #82