### PR TITLE
Remove DavException usage for parser creation and add tests

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/XmlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/XmlUtils.kt
@@ -11,7 +11,6 @@
 package at.bitfire.dav4jvm
 
 import at.bitfire.dav4jvm.XmlUtils.FEATURE_RELAXED
-import at.bitfire.dav4jvm.exception.DavException
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import org.xmlpull.v1.XmlPullParserFactory
@@ -45,6 +44,8 @@ object XmlUtils {
      *
      * First tries to create a namespace-aware parser that supports [FEATURE_RELAXED]. If that
      * fails, it falls back to a namespace-aware parser without relaxed parsing.
+     *
+     * @throws XmlPullParserException when no parser could be created
      */
     fun newPullParser(): XmlPullParser =
         try {
@@ -54,10 +55,8 @@ object XmlUtils {
             null
         }
         ?: standardFactory.newPullParser()
-        ?: throw DavException("Couldn't create XML parser")
 
     fun newSerializer(): XmlSerializer = standardFactory.newSerializer()
-        ?: throw DavException("Couldn't create XML serializer")
 
 
     fun XmlSerializer.insertTag(name: Property.Name, contentGenerator: XmlSerializer.() -> Unit = {}) {

--- a/src/test/kotlin/at/bitfire/dav4jvm/XmlUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/XmlUtilsTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class XmlUtilsTest {
+
+    @Test
+    fun newPullParser() {
+        assertNotNull(XmlUtils.newPullParser())
+    }
+
+    @Test
+    fun newSerializer() {
+        assertNotNull(XmlUtils.newSerializer())
+    }
+
+}


### PR DESCRIPTION
`DavException` is a high-level exception for WebDAV protocol errors. It should not be thrown for unrelated things like when an XML parser couldn't be created (even if this happened in WebDAV context).

The appropriate exception seems to be `XmlPullParserException` (because we don't use SAX; for that case there would be `FactoryConfigurationError` and `ParserConfigurationException`).