### PR TITLE
Add groups to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     commit-message:
       prefix: "[CI] "
     groups:
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       lib-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
- Grouped dependencies
- Also changed to weekly; I think the actual PRs will be less often. However if it's too annoying we can still reduce the frequency. On the other hand, I'd like to quickly receive updates for okhttp etc.