### PR TITLE
Make DavException and HttpException immutable; provide status code for HttpException

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
@@ -45,19 +45,6 @@ open class DavException(
 
     // constructor from Response
 
-    internal constructor(
-        message: String?,
-        cause: Throwable? = null,
-        httpResponseInfo: HttpResponseInfo
-    ): this(
-        message = message,
-        cause = cause,
-        statusCode = httpResponseInfo.statusCode,
-        requestExcerpt = httpResponseInfo.requestExcerpt,
-        responseExcerpt = httpResponseInfo.responseExcerpt,
-        errors = httpResponseInfo.errors
-    )
-
     /**
      * Takes the request, response and errors from a given HTTP response.
      *
@@ -69,10 +56,19 @@ open class DavException(
         message: String,
         cause: Throwable? = null,
         @WillNotClose response: Response
-    ) : this(
+    ) : this(message, cause, HttpResponseInfo.fromResponse(response))
+
+    private constructor(
+        message: String?,
+        cause: Throwable? = null,
+        httpResponseInfo: HttpResponseInfo
+    ): this(
         message = message,
         cause = cause,
-        httpResponseInfo = HttpResponseInfo.fromResponse(response)
+        statusCode = httpResponseInfo.statusCode,
+        requestExcerpt = httpResponseInfo.requestExcerpt,
+        responseExcerpt = httpResponseInfo.responseExcerpt,
+        errors = httpResponseInfo.errors
     )
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/DavException.kt
@@ -11,17 +11,8 @@
 package at.bitfire.dav4jvm.exception
 
 import at.bitfire.dav4jvm.Error
-import at.bitfire.dav4jvm.XmlUtils
-import at.bitfire.dav4jvm.XmlUtils.propertyName
-import okhttp3.MediaType
 import okhttp3.Response
-import okio.Buffer
-import org.xmlpull.v1.XmlPullParser
-import org.xmlpull.v1.XmlPullParserException
-import java.io.ByteArrayOutputStream
-import java.io.StringReader
 import javax.annotation.WillNotClose
-import kotlin.math.min
 
 /**
  * Signals that an error occurred during a WebDAV-related operation.
@@ -43,102 +34,46 @@ import kotlin.math.min
  * @param responseExcerpt   cached excerpt of associated HTTP response body
  * @param errors            precondition/postcondition XML elements which have been found in the XML response
  */
-open class DavException @JvmOverloads constructor(
+open class DavException(
     message: String? = null,
     cause: Throwable? = null,
-    statusCode: Int? = null,
-    requestExcerpt: String? = null,
-    responseExcerpt: String? = null,
-    errors: List<Error> = emptyList()
+    open val statusCode: Int? = null,
+    val requestExcerpt: String? = null,
+    val responseExcerpt: String? = null,
+    val errors: List<Error> = emptyList()
 ): Exception(message, cause) {
 
-    var statusCode: Int? = statusCode
-        private set
+    // constructor from Response
 
-    var requestExcerpt: String? = requestExcerpt
-        private set
-
-    var responseExcerpt: String? = responseExcerpt
-        private set
-
-    var errors: List<Error> = errors
-        private set
+    internal constructor(
+        message: String?,
+        cause: Throwable? = null,
+        httpResponseInfo: HttpResponseInfo
+    ): this(
+        message = message,
+        cause = cause,
+        statusCode = httpResponseInfo.statusCode,
+        requestExcerpt = httpResponseInfo.requestExcerpt,
+        responseExcerpt = httpResponseInfo.responseExcerpt,
+        errors = httpResponseInfo.errors
+    )
 
     /**
      * Takes the request, response and errors from a given HTTP response.
      *
-     * @param response  response to extract status code and request/response excerpt from (if possible)
      * @param message   optional exception message
      * @param cause     optional exception cause
+     * @param response  response to extract status code and request/response excerpt from (if possible)
      */
     constructor(
-        message: String?,
-        @WillNotClose response: Response,
-        cause: Throwable? = null
-    ) : this(message, cause) {
-        // extract status code
-        statusCode = response.code
-
-        // extract request body if it's text
-        val request = response.request
-        val requestExcerptBuilder = StringBuilder(
-            "${request.method} ${request.url}"
-        )
-        request.body?.let { requestBody ->
-            if (requestBody.contentType()?.isText() == true) {
-                // Unfortunately Buffer doesn't have a size limit.
-                // However large bodies are usually streaming/one-shot away.
-                val buffer = Buffer()
-                requestBody.writeTo(buffer)
-
-                ByteArrayOutputStream().use { baos ->
-                    buffer.writeTo(baos, min(buffer.size, MAX_EXCERPT_SIZE.toLong()))
-                    requestExcerptBuilder
-                        .append("\n\n")
-                        .append(baos.toString())
-                }
-            } else
-                requestExcerptBuilder.append("\n\n<request body>")
-        }
-        requestExcerpt = requestExcerptBuilder.toString()
-
-        // extract response body if it's text
-        val mimeType = response.body.contentType()
-        val responseBody =
-            if (mimeType?.isText() == true)
-                try {
-                    response.peekBody(MAX_EXCERPT_SIZE.toLong()).string()
-                } catch (_: Exception) {
-                    // response body not available anymore, probably already consumed / closed
-                    null
-                }
-            else
-                null
-        responseExcerpt = responseBody
-
-        // get XML errors from request body excerpt
-        if (mimeType?.isXml() == true && responseBody != null)
-            errors = extractErrors(responseBody)
-    }
-
-    private fun extractErrors(xml: String): List<Error> {
-        try {
-            val parser = XmlUtils.newPullParser()
-            parser.setInput(StringReader(xml))
-
-            var eventType = parser.eventType
-            while (eventType != XmlPullParser.END_DOCUMENT) {
-                if (eventType == XmlPullParser.START_TAG && parser.depth == 1)
-                    if (parser.propertyName() == Error.NAME)
-                        return Error.parseError(parser)
-                eventType = parser.next()
-            }
-        } catch (_: XmlPullParserException) {
-            // Couldn't parse XML, either invalid or maybe it wasn't even XML
-        }
-
-        return emptyList()
-    }
+        message: String,
+        cause: Throwable? = null,
+        @WillNotClose response: Response
+    ) : this(
+        message = message,
+        cause = cause,
+        httpResponseInfo = HttpResponseInfo.fromResponse(response)
+    )
 
 
     companion object {
@@ -147,13 +82,6 @@ open class DavException @JvmOverloads constructor(
          * maximum size of extracted response body
          */
         const val MAX_EXCERPT_SIZE = 20*1024
-
-        private fun MediaType.isText() =
-            type == "text" ||
-            (type == "application" && subtype in arrayOf("html", "xml"))
-
-        private fun MediaType.isXml() =
-            type in arrayOf("application", "text") && subtype == "xml"
 
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -28,7 +28,20 @@ open class HttpException(
 
     // constructor from Response
 
-    internal constructor(
+    /**
+     * Takes the request, response and errors from a given HTTP response.
+     *
+     * @param response  response to extract status code and request/response excerpt from (if possible)
+     * @param message   optional exception message
+     * @param cause     optional exception cause
+     */
+    constructor(
+        @WillNotClose response: Response,
+        message: String = "HTTP ${response.code} ${response.message}",
+        cause: Throwable? = null
+    ) : this(HttpResponseInfo.fromResponse(response), message, cause)
+
+    private constructor(
         httpResponseInfo: HttpResponseInfo,
         message: String?,
         cause: Throwable? = null
@@ -41,22 +54,19 @@ open class HttpException(
         errors = httpResponseInfo.errors
     )
 
-    /**
-     * Takes the request, response and errors from a given HTTP response.
-     *
-     * @param response  response to extract status code and request/response excerpt from (if possible)
-     * @param message   optional exception message
-     * @param cause     optional exception cause
-     */
-    constructor(
-        @WillNotClose response: Response,
-        message: String = "HTTP ${response.code} ${response.message}",
-        cause: Throwable? = null
-    ) : this(
-        message = message,
-        cause = cause,
-        httpResponseInfo = HttpResponseInfo.fromResponse(response)
-    )
 
+    // status code classes
+
+    /** Whether the [statusCode] is 3xx and thus indicates a redirection. */
+    val isRedirect
+        get() = statusCode / 100 == 3
+
+    /** Whether the [statusCode] is 3xx and thus indicates a client error. */
+    val isClientError
+        get() = statusCode / 100 == 4
+
+    /** Whether the [statusCode] is 3xx and thus indicates a server error. */
+    val isServerError
+        get() = statusCode / 100 == 5
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -61,11 +61,11 @@ open class HttpException(
     val isRedirect
         get() = statusCode / 100 == 3
 
-    /** Whether the [statusCode] is 3xx and thus indicates a client error. */
+    /** Whether the [statusCode] is 4xx and thus indicates a client error. */
     val isClientError
         get() = statusCode / 100 == 4
 
-    /** Whether the [statusCode] is 3xx and thus indicates a server error. */
+    /** Whether the [statusCode] is 5xx and thus indicates a server error. */
     val isServerError
         get() = statusCode / 100 == 5
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpException.kt
@@ -10,16 +10,53 @@
 
 package at.bitfire.dav4jvm.exception
 
+import at.bitfire.dav4jvm.Error
 import okhttp3.Response
+import javax.annotation.WillNotClose
 
 /**
  * Signals that a HTTP error was sent by the server in the context of a WebDAV operation.
  */
-open class HttpException: DavException {
+open class HttpException(
+    message: String? = null,
+    cause: Throwable? = null,
+    override val statusCode: Int,
+    requestExcerpt: String?,
+    responseExcerpt: String?,
+    errors: List<Error> = emptyList()
+): DavException(message, cause, statusCode, requestExcerpt, responseExcerpt, errors) {
 
-    constructor(response: Response) : super(
-        message = "HTTP ${response.code} ${response.message}",
-        response = response
+    // constructor from Response
+
+    internal constructor(
+        httpResponseInfo: HttpResponseInfo,
+        message: String?,
+        cause: Throwable? = null
+    ): this(
+        message = message,
+        cause = cause,
+        statusCode = httpResponseInfo.statusCode,
+        requestExcerpt = httpResponseInfo.requestExcerpt,
+        responseExcerpt = httpResponseInfo.responseExcerpt,
+        errors = httpResponseInfo.errors
     )
+
+    /**
+     * Takes the request, response and errors from a given HTTP response.
+     *
+     * @param response  response to extract status code and request/response excerpt from (if possible)
+     * @param message   optional exception message
+     * @param cause     optional exception cause
+     */
+    constructor(
+        @WillNotClose response: Response,
+        message: String = "HTTP ${response.code} ${response.message}",
+        cause: Throwable? = null
+    ) : this(
+        message = message,
+        cause = cause,
+        httpResponseInfo = HttpResponseInfo.fromResponse(response)
+    )
+
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfo.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfo.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.exception
+
+import at.bitfire.dav4jvm.Error
+import at.bitfire.dav4jvm.XmlUtils
+import at.bitfire.dav4jvm.XmlUtils.propertyName
+import at.bitfire.dav4jvm.exception.DavException.Companion.MAX_EXCERPT_SIZE
+import okhttp3.MediaType
+import okhttp3.Response
+import okio.Buffer
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import java.io.ByteArrayOutputStream
+import java.io.StringReader
+import javax.annotation.WillNotClose
+import kotlin.math.min
+
+internal class HttpResponseInfo private constructor(
+    val statusCode: Int,
+    val requestExcerpt: String?,
+    val responseExcerpt: String?,
+    val errors: List<Error>
+) {
+
+    companion object {
+
+        fun fromResponse(@WillNotClose response: Response): HttpResponseInfo {
+            // extract request body if it's text
+            val request = response.request
+            val requestExcerptBuilder = StringBuilder(
+                "${request.method} ${request.url}"
+            )
+            request.body?.let { requestBody ->
+                if (requestBody.contentType()?.isText() == true) {
+                    // Unfortunately Buffer doesn't have a size limit.
+                    // However large bodies are usually streaming/one-shot away.
+                    val buffer = Buffer()
+                    requestBody.writeTo(buffer)
+
+                    ByteArrayOutputStream().use { baos ->
+                        buffer.writeTo(baos, min(buffer.size, MAX_EXCERPT_SIZE.toLong()))
+                        requestExcerptBuilder
+                            .append("\n\n")
+                            .append(baos.toString())
+                    }
+                } else
+                    requestExcerptBuilder.append("\n\n<request body>")
+            }
+
+            // extract response body if it's text
+            val mimeType = response.body.contentType()
+            val responseBody =
+                if (mimeType?.isText() == true)
+                    try {
+                        response.peekBody(MAX_EXCERPT_SIZE.toLong()).string()
+                    } catch (_: Exception) {
+                        // response body not available anymore, probably already consumed / closed
+                        null
+                    }
+                else
+                    null
+
+            // get XML errors from request body excerpt
+            val errors: List<Error> = if (mimeType?.isXml() == true && responseBody != null)
+                extractErrors(responseBody)
+            else
+                emptyList()
+
+            return HttpResponseInfo(
+                statusCode = response.code,
+                requestExcerpt = requestExcerptBuilder.toString(),
+                responseExcerpt = responseBody,
+                errors = errors
+            )
+        }
+
+        private fun extractErrors(xml: String): List<Error> {
+            try {
+                val parser = XmlUtils.newPullParser()
+                parser.setInput(StringReader(xml))
+
+                var eventType = parser.eventType
+                while (eventType != XmlPullParser.END_DOCUMENT) {
+                    if (eventType == XmlPullParser.START_TAG && parser.depth == 1)
+                        if (parser.propertyName() == Error.NAME)
+                            return Error.parseError(parser)
+                    eventType = parser.next()
+                }
+            } catch (_: XmlPullParserException) {
+                // Couldn't parse XML, either invalid or maybe it wasn't even XML
+            }
+
+            return emptyList()
+        }
+
+
+        // extensions
+
+        private fun MediaType.isText() =
+            type == "text" ||
+                    (type == "application" && subtype in arrayOf("html", "xml"))
+
+        private fun MediaType.isXml() =
+            type in arrayOf("application", "text") && subtype == "xml"
+
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfo.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfo.kt
@@ -53,7 +53,7 @@ internal class HttpResponseInfo private constructor(
                             .append(baos.toString())
                     }
                 } else
-                    requestExcerptBuilder.append("\n\n<request body>")
+                    requestExcerptBuilder.append("\n\n<request body (${requestBody.contentLength()} bytes)>")
             }
 
             // extract response body if it's text

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/DavExceptionTest.kt
@@ -55,7 +55,7 @@ class DavExceptionTest {
             .build()).execute()
         response.close()
 
-        val result = DavException("Test", response)
+        val result = DavException("Test", response = response)
         assertNull(result.responseExcerpt)
     }
 
@@ -71,7 +71,7 @@ class DavExceptionTest {
             .post("Sample".toRequestBody("application/test".toMediaType()))
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertEquals("POST $url\n\n<request body>", result.requestExcerpt)
         }
     }
@@ -88,7 +88,7 @@ class DavExceptionTest {
             .post("*".repeat(DavException.MAX_EXCERPT_SIZE * 2).toRequestBody("text/css".toMediaType()))
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             val truncatedText = "*".repeat(DavException.MAX_EXCERPT_SIZE)
             assertEquals("POST $url\n\n$truncatedText", result.requestExcerpt)
         }
@@ -107,7 +107,7 @@ class DavExceptionTest {
             .get()
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertNull(result.responseExcerpt)
         }
     }
@@ -125,7 +125,7 @@ class DavExceptionTest {
             .get()
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertEquals("Interesting details about error", result.responseExcerpt)
         }
     }
@@ -143,7 +143,7 @@ class DavExceptionTest {
             .get()
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertEquals(
                 "0123456789".repeat(2*1024),    // limited to 20 kB
                 result.responseExcerpt
@@ -163,7 +163,7 @@ class DavExceptionTest {
             .get()
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertNull(result.responseExcerpt)
         }
     }
@@ -188,7 +188,7 @@ class DavExceptionTest {
             .get()
             .build()
         ).execute().use { response ->
-            val result = DavException("Test", response)
+            val result = DavException("Test", response = response)
             assertEquals(xml, result.responseExcerpt)
             assertEquals(
                 listOf(

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpExceptionTest.kt
@@ -12,12 +12,11 @@ package at.bitfire.dav4jvm.exception
 
 import at.bitfire.dav4jvm.Error
 import at.bitfire.dav4jvm.Property
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -26,36 +25,71 @@ import java.io.FileNotFoundException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 
-class DavExceptionTest {
+class HttpExceptionTest {
 
     @Test
-    fun fromResponse() {
+    fun isRedirect() {
         val request = Request.Builder()
             .get()
             .url("https://example.com")
             .build()
-        val cause = Exception()
         val result = Response.Builder()
             .request(request)
             .protocol(Protocol.HTTP_1_1)
-            .code(200)
-            .message("OK")
-            .body("Your Information".toResponseBody("text/plain".toMediaType()))
+            .code(302)
+            .message("Found")
             .build()
             .use { response ->
-                DavException("Message", cause, response)
+                HttpException(response, "Message")
             }
-        assertEquals("Message", result.message)
-        assertEquals(cause, result.cause)
-        assertEquals(200, result.statusCode)
-        assertEquals("GET https://example.com/", result.requestExcerpt)
-        assertEquals("Your Information", result.responseExcerpt)
-        assertTrue(result.errors.isEmpty())
+        assertTrue(result.isRedirect)
+        assertFalse(result.isClientError)
+        assertFalse(result.isServerError)
+    }
+
+    @Test
+    fun isClientError() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .build()
+            .use { response ->
+                HttpException(response, "Message")
+            }
+        assertFalse(result.isRedirect)
+        assertTrue(result.isClientError)
+        assertFalse(result.isServerError)
+    }
+
+    @Test
+    fun isServerError() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(500)
+            .message("Internal Server Error")
+            .build()
+            .use { response ->
+                HttpException(response, "Message")
+            }
+        assertFalse(result.isRedirect)
+        assertFalse(result.isClientError)
+        assertTrue(result.isServerError)
     }
 
     @Test
     fun `is Java-serializable`() {
-        val ex = DavException(
+        val ex = HttpException(
             message = "Some Error",
             statusCode = 500,
             requestExcerpt = "Request Body",
@@ -77,7 +111,7 @@ class DavExceptionTest {
         // deserialize
         ByteArrayInputStream(blob).use { bais ->
             ObjectInputStream(bais).use { ois ->
-                val actual = ois.readObject() as DavException
+                val actual = ois.readObject() as HttpException
                 assertEquals(ex.message, actual.message)
                 assertEquals(ex.statusCode, actual.statusCode)
                 assertEquals(ex.requestExcerpt, actual.requestExcerpt)

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfoTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/HttpResponseInfoTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.exception
+
+import at.bitfire.dav4jvm.Error
+import at.bitfire.dav4jvm.Property
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HttpResponseInfoTest {
+
+    // requestExcerpt
+
+    @Test
+    fun `requestExcerpt (binary blob)`() {
+        val request = Request.Builder()
+            .post("Sample".toRequestBody("application/test".toMediaType()))
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(204)
+            .message("No Content")
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+        assertEquals("POST https://example.com/\n\n<request body (6 bytes)>", result.requestExcerpt)
+    }
+
+    @Test
+    fun `requestExcerpt (large CSS text)`() {
+        val request = Request.Builder()
+            .post("*".repeat(DavException.MAX_EXCERPT_SIZE * 2).toRequestBody("text/css".toMediaType()))
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(204)
+            .message("No Content")
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+        val truncatedText = "*".repeat(DavException.MAX_EXCERPT_SIZE)
+        assertEquals("POST https://example.com/\n\n$truncatedText", result.requestExcerpt)
+    }
+
+
+    // responseExcerpt
+
+    @Test
+    fun `responseExcerpt (binary blob)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .body("Evil binary data".toResponseBody("application/octet-stream".toMediaType()))
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+        assertNull(result.responseExcerpt)
+    }
+
+    @Test
+    fun `responseExcerpt (HTML)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .body("Interesting details about error".toResponseBody("text/html".toMediaType()))
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+        assertEquals("Interesting details about error", result.responseExcerpt)
+    }
+
+    @Test
+    fun `responseExcerpt (large HTML)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .body("0123456789".repeat(3 * 1024).toResponseBody("text/html".toMediaType()))    // 30 kB
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+        assertEquals(
+            "0123456789".repeat(2 * 1024),    // limited to 20 kB
+            result.responseExcerpt
+        )
+    }
+
+    @Test
+    fun `responseExcerpt (closed response)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val response = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("Some Response".toResponseBody())
+            .build()
+
+        response.close()
+
+        val result = HttpResponseInfo.fromResponse(response)
+        assertNull(result.responseExcerpt)
+    }
+
+    @Test
+    fun `responseExcerpt (no MIME type)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("Maybe evil binary data".toResponseBody())
+            .build()
+            .use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+
+        assertNull(result.responseExcerpt)
+    }
+
+    @Test
+    fun `responseExcerpt (XML with error elements)`() {
+        val request = Request.Builder()
+            .get()
+            .url("https://example.com")
+            .build()
+        val xml = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <D:error xmlns:D="DAV:">
+                <D:lock-token-submitted>
+                    <D:href>/locked/</D:href>
+                </D:lock-token-submitted>
+            </D:error>
+            """.trimIndent()
+        val result = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(xml.toResponseBody("application/xml".toMediaType()))
+            .build().use { response ->
+                HttpResponseInfo.fromResponse(response)
+            }
+
+        assertEquals(xml, result.responseExcerpt)
+        assertEquals(
+            listOf(
+                Error(Property.Name("DAV:", "lock-token-submitted"))
+            ),
+            result.errors
+        )
+    }
+
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableExceptionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/exception/ServiceUnavailableExceptionTest.kt
@@ -23,13 +23,15 @@ import java.time.Instant
 class ServiceUnavailableExceptionTest {
 
     val response503 = Response.Builder()
-            .request(Request.Builder()
-                    .url("http://www.example.com")
-                    .get()
-                    .build())
-            .protocol(Protocol.HTTP_1_1)
-            .code(503).message("Try later")
-            .build()
+        .request(
+            Request.Builder()
+                .url("http://www.example.com")
+                .get()
+                .build()
+        )
+        .protocol(Protocol.HTTP_1_1)
+        .code(503).message("Try later")
+        .build()
 
     @Test
     fun testRetryAfter_NoTime() {
@@ -40,8 +42,8 @@ class ServiceUnavailableExceptionTest {
     @Test
     fun testRetryAfter_Seconds() {
         val response = response503.newBuilder()
-                .header("Retry-After", "120")
-                .build()
+            .header("Retry-After", "120")
+            .build()
         val e = ServiceUnavailableException(response)
         assertNotNull(e.retryAfter)
         assertTrue(withinTimeRange(e.retryAfter!!, 120))
@@ -49,13 +51,13 @@ class ServiceUnavailableExceptionTest {
 
     @Test
     fun testRetryAfter_Date() {
-        val after30min = Instant.now().plusSeconds(30*60)
+        val after30min = Instant.now().plusSeconds(30 * 60)
         val response = response503.newBuilder()
-                .header("Retry-After", HttpUtils.formatDate(after30min))
-                .build()
+            .header("Retry-After", HttpUtils.formatDate(after30min))
+            .build()
         val e = ServiceUnavailableException(response)
         assertNotNull(e.retryAfter)
-        assertTrue(withinTimeRange(e.retryAfter!!, 30*60))
+        assertTrue(withinTimeRange(e.retryAfter!!, 30 * 60))
     }
 
 


### PR DESCRIPTION
Addresses the `DavException` and `HttpException` issues mentioned in #93:

- Exception data is now immutable (and only consists of serializable data types).
- `HttpException` is guaranteed to have a status code. The status codes 3xx, 4xx and 5xx can now explicitly be detected by `isRedirect` etc., as this is often used by DAVx⁵.

Extracting the HTTP information (status code request/response excerpt) has been moved to a separate class which is also tested separately.