### PR TITLE
Update Java version to 21 and remove `--no-daemon` flag

### DIFF
--- a/.github/workflows/build-kdoc.yml
+++ b/.github/workflows/build-kdoc.yml
@@ -18,11 +18,11 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
 
       - name: Build KDoc
-        run: ./gradlew --no-daemon dokkaGenerate
+        run: ./gradlew dokkaGenerate
 
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
 
       - name: Check
-        run: ./gradlew --no-daemon check
+        run: ./gradlew check
 

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,4 @@
+#
+# https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:configuring_daemon_jvm
+#
+toolchainVersion=21


### PR DESCRIPTION
Bumps Java version from 17 to 21 in CI workflows and adds `gradle-daemon-jvm.properties` with toolchain version 21. Removes the `--no-daemon` flag from `dokkaGenerate` and `check` Gradle tasks.