### PR TITLE
Deprecate okhttp package

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/BasicDigestAuthHandler.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/BasicDigestAuthHandler.kt
@@ -38,6 +38,7 @@ import java.util.logging.Logger
  *
  * Usage: Set as authenticator *and* as network interceptor.
  */
+@Deprecated("Use Ktor's built-in authentication mechanisms instead. See at.bitfire.dav4jvm.ktor package.")
 class BasicDigestAuthHandler(
     /** Authenticate only against hosts ending with this domain (may be null, which means no restriction) */
     val domain: String?,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/CallbackInterfaces.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/CallbackInterfaces.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.CallbackInterfaces"))
 /**
  * Callback for the OPTIONS request.
  */
@@ -19,6 +20,7 @@ fun interface CapabilitiesCallback {
     fun onCapabilities(davCapabilities: Set<String>, response: Response)
 }
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.CallbackInterfaces"))
 /**
  * Callback for 207 Multi-Status responses.
  */
@@ -36,6 +38,7 @@ fun interface MultiResponseCallback {
     fun onResponse(response: at.bitfire.dav4jvm.okhttp.Response, relation: at.bitfire.dav4jvm.okhttp.Response.HrefRelation)
 }
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.CallbackInterfaces"))
 /**
  * Callback for HTTP responses.
  */

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavAddressBook.kt
@@ -24,6 +24,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.StringWriter
 import java.util.logging.Logger
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.DavAddressBook"))
 @Suppress("unused")
 class DavAddressBook @JvmOverloads constructor(
     httpClient: OkHttpClient,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavCalendar.kt
@@ -32,6 +32,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 import java.util.logging.Logger
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.DavCalendar"))
 @Suppress("unused")
 class DavCalendar @JvmOverloads constructor(
     httpClient: OkHttpClient,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavCollection.kt
@@ -27,6 +27,7 @@ import java.util.logging.Logger
 /**
  * Represents a WebDAV collection.
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.DavCollection"))
 open class DavCollection @JvmOverloads constructor(
     httpClient: OkHttpClient,
     location: HttpUrl,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/DavResource.kt
@@ -63,6 +63,7 @@ import at.bitfire.dav4jvm.okhttp.Response as DavResponse
  * @param location      location of the WebDAV resource
  * @param logger        will be used for logging
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.DavResource"))
 open class DavResource @JvmOverloads constructor(
     val httpClient: OkHttpClient,
     location: HttpUrl,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/OkHttpUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/OkHttpUtils.kt
@@ -13,6 +13,7 @@ package at.bitfire.dav4jvm.okhttp
 import okhttp3.HttpUrl
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.KtorHttpUtils"))
 object OkHttpUtils {
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/PropStat.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/PropStat.kt
@@ -24,6 +24,7 @@ import java.util.LinkedList
  *
  *     <!ELEMENT propstat (prop, status, error?, responsedescription?) >
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.PropStat"))
 data class PropStat(
     val properties: List<Property>,
     val status: StatusLine,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/Response.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/Response.kt
@@ -29,6 +29,7 @@ import java.util.logging.Logger
  *     <!ELEMENT response (href, ((href*, status)|(propstat+)),
  *                         error?, responsedescription? , location?) >
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.Response"))
 @Suppress("unused")
 data class Response(
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/UrlUtils.kt
@@ -14,6 +14,7 @@ import at.bitfire.dav4jvm.okhttp.UrlUtils.omitTrailingSlash
 import at.bitfire.dav4jvm.okhttp.UrlUtils.withTrailingSlash
 import okhttp3.HttpUrl
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.UrlUtils"))
 object UrlUtils {
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ConflictException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ConflictException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.ConflictException"))
 class ConflictException: HttpException {
 
     constructor(response: Response) : super(response) {

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/DavException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/DavException.kt
@@ -34,6 +34,7 @@ import javax.annotation.WillNotClose
  * @param responseExcerpt   cached excerpt of associated HTTP response body
  * @param errors            precondition/postcondition XML elements which have been found in the XML response
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.DavException"))
 open class DavException(
     message: String? = null,
     cause: Throwable? = null,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ForbiddenException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ForbiddenException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.ForbiddenException"))
 class ForbiddenException: HttpException {
 
     constructor(response: Response) : super(response) {

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/GoneException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/GoneException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.GoneException"))
 class GoneException: HttpException {
 
     constructor(response: Response) : super(response) {

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/HttpException.kt
@@ -17,6 +17,7 @@ import javax.annotation.WillNotClose
 /**
  * Signals that a HTTP error was sent by the server in the context of a WebDAV operation.
  */
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.HttpException"))
 open class HttpException(
     message: String? = null,
     cause: Throwable? = null,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/HttpResponseInfo.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/HttpResponseInfo.kt
@@ -25,6 +25,7 @@ import java.io.StringReader
 import javax.annotation.WillNotClose
 import kotlin.math.min
 
+@Deprecated("Internal helper class. Use Ktor equivalents instead.")
 internal class HttpResponseInfo private constructor(
     val statusCode: Int,
     val requestExcerpt: String?,

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/NotFoundException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/NotFoundException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.NotFoundException"))
 class NotFoundException : HttpException {
 
     constructor(response: Response) : super(response) {

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/PreconditionFailedException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/PreconditionFailedException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.PreconditionFailedException"))
 class PreconditionFailedException: HttpException {
 
     constructor(response: Response) : super(response) {

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ServiceUnavailableException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/ServiceUnavailableException.kt
@@ -19,6 +19,7 @@ import java.time.Instant
 import java.util.logging.Level
 import java.util.logging.Logger
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.ServiceUnavailableException"))
 class ServiceUnavailableException(response: Response) : HttpException(response) {
 
     private val logger

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/exception/UnauthorizedException.kt
@@ -12,6 +12,7 @@ package at.bitfire.dav4jvm.okhttp.exception
 
 import okhttp3.Response
 
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.exception.UnauthorizedException"))
 class UnauthorizedException: HttpException {
 
     constructor(response: Response) : super(response) {


### PR DESCRIPTION
Mark all classes in the at.bitfire.dav4jvm.okhttp package (and its subpackages) as deprecated, directing users to use the corresponding Ktor classes in at.bitfire.dav4jvm.ktor instead.

- Added `@Deprecated` annotations with ReplaceWith to all classes/objects that have direct Ktor equivalents
- Added descriptive deprecation messages for classes without direct equivalents (BasicDigestAuthHandler, HttpResponseInfo)
- Preserved existing `@Deprecated` annotation on DavResource.get() method