### PR TITLE
Replace custom HTTP date parsing/formatting with Ktor functions

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/HttpUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/HttpUtils.kt
@@ -10,43 +10,31 @@
 
 package at.bitfire.dav4jvm
 
-import at.bitfire.dav4jvm.HttpUtils.httpDateFormat
 import io.ktor.http.Url
+import io.ktor.http.fromHttpToGmtDate
+import io.ktor.http.toHttpDate
+import io.ktor.util.date.GMTDate
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
-import java.util.Locale
 import java.util.logging.Logger
 
 object HttpUtils {
-
-    /**
-     * Preferred HTTP date/time format, see RFC 7231 7.1.1.1 IMF-fixdate
-     */
-    private const val httpDateFormatStr = "EEE, dd MMM yyyy HH:mm:ss z"
-    private val httpDateFormat = DateTimeFormatter.ofPattern(httpDateFormatStr, Locale.US)
 
     private val logger
         get() = Logger.getLogger(javaClass.name)
 
     /**
-     * Formats a date for use in HTTP headers using [httpDateFormat].
+     * Formats a date for use in HTTP headers (RFC 7231 IMF-fixdate).
      *
      * @param date date to be formatted
-     *
      * @return date in HTTP-date format
      */
     fun formatDate(date: Instant): String =
-        ZonedDateTime.ofInstant(date, ZoneId.of("GMT")).format(httpDateFormat)
+        GMTDate(date.toEpochMilli()).toHttpDate()
 
     /**
-     * Parses a HTTP-date according to RFC 7231 section 7.1.1.1.
+     * Parses an HTTP-date according to RFC 7231 section 7.1.1.1.
      *
      * @param dateStr date-time formatted in one of the three accepted formats:
      *
@@ -56,33 +44,12 @@ object HttpUtils {
      *
      * @return date-time, or null if date could not be parsed
      */
-    fun parseDate(dateStr: String): Instant? {
-        val zonedFormats = arrayOf(
-            // preferred format
-            httpDateFormat,
-
-            // obsolete RFC 850 format
-            DateTimeFormatter.ofPattern("EEEE, dd-MMM-yy HH:mm:ss zzz", Locale.US),
-        )
-
-        // try the two formats with zone info
-        for (format in zonedFormats)
-            try {
-                return ZonedDateTime.parse(dateStr, format).toInstant()
-            } catch (ignored: DateTimeParseException) {
-            }
-
-        // try ANSI C's asctime() format
-        try {
-            val formatC = DateTimeFormatter.ofPattern("EEE MMM ppd HH:mm:ss yyyy", Locale.US)
-            val local = LocalDateTime.parse(dateStr, formatC)
-            return local.atZone(ZoneOffset.UTC).toInstant()
-        } catch (ignored: DateTimeParseException) {
-        }
-
-        // no success in parsing
+    fun parseDate(dateStr: String): Instant? = try {
+        val ts = dateStr.fromHttpToGmtDate().timestamp
+        Instant.ofEpochMilli(ts)
+    } catch (_: Exception) {
         logger.warning("Couldn't parse HTTP date: $dateStr, ignoring")
-        return null
+        null
     }
 
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/HttpUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/HttpUtilsTest.kt
@@ -23,11 +23,8 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import java.util.Calendar
-import java.util.Locale
 import java.util.TimeZone
-import java.util.logging.Logger
 
 class HttpUtilsTest {
 
@@ -48,7 +45,6 @@ class HttpUtilsTest {
 
     @Test
     fun formatDate_timezone_is_GMT() {
-        // z pattern with ZoneOffset.UTC produces "Z" not "GMT"; ZoneId.of("GMT") is needed
         // See https://github.com/bitfireAT/dav4jvm/issues/22
         assertTrue(HttpUtils.formatDate(Instant.EPOCH).endsWith(" GMT"))
     }
@@ -61,36 +57,14 @@ class HttpUtilsTest {
 
     @Test
     fun parseDate_IMF_FixDate_GMT() {
-        // ZZZZ pattern fails on Android (requires "GMT+00:00"); z pattern accepts bare "GMT"
         // See https://github.com/bitfireAT/dav4jvm/issues/22
         assertEquals(Instant.parse("2026-05-04T22:51:02Z"), HttpUtils.parseDate("Mon, 04 May 2026 22:51:02 GMT"))
     }
 
     @Test
     fun parseDate_RFC850_1994() {
-        // obsolete RFC 850 format – fails when run after year 2000 because 06 Nov 2094 (!) is not a Sunday
+        // obsolete RFC 850 format – 2-digit year cannot be parsed, returns null
         assertNull(HttpUtils.parseDate("Sun, 06-Nov-94 08:49:37 GMT"))
-    }
-
-    @Test
-    fun parseDate_RFC850_2004_CEST() {
-        // obsolete RFC 850 format with European time zone
-        assertEquals(Instant.ofEpochSecond(1689317377), HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 CEST"))
-    }
-
-    @Test
-    fun parseDate_RFC850_2004_GMT() {
-        // obsolete RFC 850 format
-        assertEquals(Instant.ofEpochSecond(1689324577), HttpUtils.parseDate("Friday, 14-Jul-23 08:49:37 GMT"))
-    }
-
-    @Test
-    fun parseDate_ANSI_C() {
-        // ANSI C's asctime() format
-        val logger = Logger.getLogger(javaClass.name)
-        logger.info("Expected date: " + DateTimeFormatter.ofPattern("EEE MMM ppd HH:mm:ss yyyy", Locale.US).format(ZonedDateTime.now()))
-
-        assertEquals(Instant.ofEpochSecond(784111777), HttpUtils.parseDate("Sun Nov  6 08:49:37 1994"))
     }
 
 


### PR DESCRIPTION
- Use Ktor conversion methods for [HTTP-date](https://httpwg.org/specs/rfc9110.html#http.date)
- Drop support for obsolete HTTP-date formats that are not used anymore and not supported by Ktor