### PR TITLE
Replace SLF4J logging with JUL

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -25,14 +25,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
-import io.ktor.util.logging.Logger
-import org.slf4j.LoggerFactory
+import java.util.logging.Logger
 import java.io.StringWriter
 
 class DavAddressBook(
     httpClient: HttpClient,
     location: Url,
-    logger: Logger = LoggerFactory.getLogger(DavAddressBook::javaClass.name)
+    logger: Logger = Logger.getLogger(javaClass.name)
 ): DavCollection(httpClient, location, logger) {
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -19,8 +19,7 @@ import at.bitfire.dav4jvm.property.webdav.WebDAV
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.util.logging.*
-import org.slf4j.LoggerFactory
+import java.util.logging.Logger
 import java.io.StringWriter
 import java.time.Instant
 import java.time.ZoneOffset
@@ -32,7 +31,7 @@ import java.util.Locale
 class DavCalendar(
     httpClient: HttpClient,
     location: Url,
-    logger: Logger = LoggerFactory.getLogger(DavCalendar::javaClass.name)
+    logger: Logger = Logger.getLogger(javaClass.name)
 ): DavCollection(httpClient, location, logger) {
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -22,8 +22,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
-import io.ktor.util.logging.Logger
-import org.slf4j.LoggerFactory
+import java.util.logging.Logger
 import java.io.StringWriter
 
 /**
@@ -32,7 +31,7 @@ import java.io.StringWriter
 open class DavCollection @JvmOverloads constructor(
     httpClient: HttpClient,
     location: Url,
-    logger: Logger = LoggerFactory.getLogger(DavCollection::class.java.name)
+    logger: Logger = Logger.getLogger(javaClass.name)
 ): DavResource(httpClient, location, logger) {
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -47,12 +47,13 @@ import io.ktor.http.isSecure
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
 import io.ktor.http.withCharset
-import io.ktor.util.logging.Logger
+import java.util.logging.Level
+import java.util.logging.Logger
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import io.ktor.utils.io.peek
 import kotlinx.io.bytestring.encodeToByteString
-import org.slf4j.LoggerFactory
+
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
 import java.io.EOFException
@@ -84,7 +85,7 @@ import java.io.StringWriter
 open class DavResource(
     val httpClient: HttpClient,
     location: Url,
-    val logger: Logger = LoggerFactory.getLogger(DavResource::class.java.name)
+    val logger: Logger = Logger.getLogger(javaClass.name)
 ) {
 
     companion object {
@@ -677,7 +678,7 @@ open class DavResource(
 
         val contentType = httpResponse.contentType()
         if (contentType == null) {
-            logger.warn("Received 207 Multi-Status without Content-Type, assuming XML")
+            logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
             return  // supposed XML response body, fine
         }
 
@@ -690,11 +691,11 @@ open class DavResource(
         try {
             val firstBytes = bodyChannel.peek(XML_SIGNATURE.size)
             if (firstBytes == XML_SIGNATURE) {
-                logger.warn("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
+                logger.warning("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
                 return  // response body starts with XML signature, fine
             }
         } catch (e: Exception) {
-            logger.warn("Couldn't scan for XML signature", e)
+            logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
         }
 
         // non-XML response body


### PR DESCRIPTION
- Replace org.slf4j.LoggerFactory with java.util.Logger
- Replace io.ktor.util.logging.Logger with java.util.logging.Logger
- Update logger defaults to use Logger.getLogger(javaClass.name)
- Change .warn() calls to .warning() or .log(Level.WARNING, ...)
- Keep logger as constructor parameter to allow custom logger injection

Affected files:
- ktor/DavResource.kt
- ktor/DavCollection.kt
- ktor/DavCalendar.kt
- ktor/DavAddressBook.kt