### PR TITLE
[Ktor] Refactor HTTP utilities to use top-level extensions

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/ContentTypeUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/ContentTypeUtils.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.http.BadContentTypeFormatException
+import io.ktor.http.ContentType
+
+/**
+ * Checks if this content type represents a text format.
+ *
+ * @return true if this content type is XML or matches Text.Any
+ */
+fun ContentType.isText() =
+    isXml() || match(ContentType.Text.Any)
+
+/**
+ * Checks if this content type represents an XML format.
+ *
+ * @return true if this content type matches Application.Xml or Text.Xml
+ */
+fun ContentType.isXml() =
+    match(ContentType.Application.Xml) || match(ContentType.Text.Xml)
+
+/**
+ * Converts a string to a [ContentType], if possible.
+ *
+ * @return the [ContentType], or `null` if the string is null or couldn't be parsed
+ */
+fun String?.toContentTypeOrNull(): ContentType? {
+    if (this == null)
+        return null
+
+    return try {
+        ContentType.parse(this)
+    } catch (_: BadContentTypeFormatException) {
+        null
+    }
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -279,7 +279,7 @@ open class DavResource(
         callback: ResponseCallback
     ) {
         followRedirects({
-            httpClient.prepareRequest(UrlUtils.withTrailingSlash(location)) {
+            httpClient.prepareRequest(location.withTrailingSlash()) {
                 method = HttpMethod.parse(methodName)
 
                 if (additionalHeaders != null)

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -149,7 +149,7 @@ open class DavResource(
      * File name of this resource (determined from [location])
      */
     val fileName
-        get() = KtorHttpUtils.fileName(location)
+        get() = HttpUtils.fileName(location)
 
 
     /**
@@ -192,7 +192,7 @@ open class DavResource(
         // check for success
         checkStatus(response)
 
-        val capabilities = KtorHttpUtils.listHeader(response, "DAV")
+        val capabilities = HttpUtils.listHeader(response, "DAV")
         callback.onCapabilities(
             capabilities.map { it.trim() }.toSet(),
             response

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/HttpUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/HttpUtils.kt
@@ -11,12 +11,10 @@
 package at.bitfire.dav4jvm.ktor
 
 import io.ktor.client.statement.HttpResponse
-import io.ktor.http.BadContentTypeFormatException
-import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 
-object KtorHttpUtils {
+object HttpUtils {
 
     val INVALID_STATUS = HttpStatusCode( 500, "Invalid status line")
 
@@ -94,47 +92,5 @@ object KtorHttpUtils {
         } else {
             INVALID_STATUS
         }
-    }
-}
-
-
-// extension methods
-
-fun ContentType.isText() =
-    isXml() || match(ContentType.Text.Any)
-
-fun ContentType.isXml() =
-    match(ContentType.Application.Xml) || match(ContentType.Text.Xml)
-
-fun String?.toContentTypeOrNull(): ContentType? {
-    if (this == null)
-        return null
-
-    return try {
-        ContentType.parse(this)
-    } catch (_: BadContentTypeFormatException) {
-        null
-    }
-}
-
-/**
- * Converts the [String] into a Ktor [Url], if possible.
- *
- * Differs from [io.ktor.http.parseUrl]:
- *
- * - `"relative".toUrlOrNull() == Url("relative")` (without host) but
- * - `parseUrl("relative") == null` (requires host)
- *
- * @return the Ktor [Url], or `null` if the string couldn't be converted
- */
-fun String?.toUrlOrNull(): Url? {
-    if (this == null)
-        return null
-
-    return try {
-        Url(this)
-    } catch (_: Exception) {
-        // parseUrl doesn't catch URLDecodeException, see https://github.com/ktorio/ktor/pull/5231
-        null
     }
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/PropStatParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/PropStatParser.kt
@@ -34,7 +34,7 @@ object PropStatParser {
                     WebDAV.Prop ->
                         prop.addAll(Property.parse(parser))
                     WebDAV.Status ->
-                        status = KtorHttpUtils.parseStatusLine(parser.nextText())
+                        status = HttpUtils.parseStatusLine(parser.nextText())
                 }
             eventType = parser.next()
         }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/Response.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/Response.kt
@@ -88,6 +88,6 @@ data class Response(
     /**
      * Returns the name (last path segment) of the resource.
      */
-    fun hrefName() = KtorHttpUtils.fileName(href)
+    fun hrefName() = HttpUtils.fileName(href)
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
@@ -67,7 +67,7 @@ class ResponseParser(
                     WebDAV.Href ->
                         hrefOrNull = resolveHref(parser.nextText())
                     WebDAV.Status ->
-                        status = KtorHttpUtils.parseStatusLine(parser.nextText())
+                        status = HttpUtils.parseStatusLine(parser.nextText())
                     WebDAV.PropStat ->
                         PropStatParser.parse(parser).let { propStat += it }
                     WebDAV.Error ->

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
@@ -92,12 +92,12 @@ class ResponseParser(
             .firstOrNull()
             ?.let { type ->
                 if (type.types.contains(WebDAV.Collection))
-                    href = UrlUtils.withTrailingSlash(href)
+                    href = href.withTrailingSlash()
             }
 
         // Which resource does this <response> represent?
         val relation = when {
-            UrlUtils.omitTrailingSlash(href).equalsForWebDAV(UrlUtils.omitTrailingSlash(location)) ->
+            href.omitTrailingSlash().equalsForWebDAV(location.omitTrailingSlash()) ->
                 HrefRelation.SELF
 
             else -> {

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
@@ -128,3 +128,25 @@ fun Url.equalsForWebDAV(other: Url): Boolean {
             && this.port == other.port
             && this.rawSegments == other.rawSegments
 }
+
+/**
+ * Converts the [String] into a Ktor [Url], if possible.
+ *
+ * Differs from [io.ktor.http.parseUrl]:
+ *
+ * - `"relative".toUrlOrNull() == Url("relative")` (without host) but
+ * - `parseUrl("relative") == null` (requires host)
+ *
+ * @return the Ktor [Url], or `null` if the string couldn't be converted
+ */
+fun String?.toUrlOrNull(): Url? {
+    if (this == null)
+        return null
+
+    return try {
+        Url(this)
+    } catch (_: Exception) {
+        // parseUrl doesn't catch URLDecodeException, see https://github.com/ktorio/ktor/pull/5231
+        null
+    }
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
@@ -10,8 +10,6 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import at.bitfire.dav4jvm.ktor.UrlUtils.omitTrailingSlash
-import at.bitfire.dav4jvm.ktor.UrlUtils.withTrailingSlash
 import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.takeFrom
@@ -41,39 +39,52 @@ object UrlUtils {
             withoutTrailingDot
     }
 
-    /**
-     * Ensures that a given URL doesn't have a trailing slash after member names.
-     * If the path is the root path (`/`), the slash is preserved.
-     *
-     * @param url URL to process (e.g. 'http://host/test1/')
-     *
-     * @return URL without trailing slash (except when the path is the root path), e.g. `http://host/test1`
-     */
-    fun omitTrailingSlash(url: Url): Url {
-        val hasTrailingSlash = url.rawSegments.isNotEmpty() && url.rawSegments.last() == ""
+}
 
-        return if (hasTrailingSlash)
-            URLBuilder(url).apply { pathSegments = pathSegments.dropLast(1) }.build()
+/**
+ * Ensures that a given URL doesn't have a trailing slash after member names.
+ * If the path is the root path (`/`), the slash is preserved.
+ *
+ * @return URL without trailing slash (except when the path is the root path), e.g. `http://host/test1`
+ */
+fun Url.omitTrailingSlash(): Url {
+    val hasTrailingSlash = this.rawSegments.isNotEmpty() && this.rawSegments.last() == ""
+
+    return if (hasTrailingSlash)
+        URLBuilder(this).apply { pathSegments = pathSegments.dropLast(1) }.build()
+    else
+        this
+}
+
+/**
+ * Ensures that a given URL has a trailing slash after member names.
+ *
+ * @return URL with trailing slash, e.g. `http://host/test1/`
+ */
+fun Url.withTrailingSlash(): Url {
+    val hasTrailingSlash = this.rawSegments.isNotEmpty() && this.rawSegments.last() == ""
+
+    return if (hasTrailingSlash)
+        this
+    else
+        URLBuilder(this).apply { pathSegments += "" }.build()
+}
+
+/**
+ * Returns parent URL (parent folder). Always with trailing slash.
+ */
+fun Url.parent(): Url {
+    val segments = this.rawSegments
+    if (segments.size <= 1)
+    // root URL, ensure it has trailing slash
+        return if (segments.lastOrNull() == "")
+            this
         else
-            url
-    }
-
-    /**
-     * Ensures that a given URL has a trailing slash after member names.
-     *
-     * @param url URL to process (e.g. 'http://host/test1')
-     *
-     * @return URL with trailing slash, e.g. `http://host/test1/`
-     */
-    fun withTrailingSlash(url: Url): Url {
-        val hasTrailingSlash = url.rawSegments.isNotEmpty() && url.rawSegments.last() == ""
-
-        return if (hasTrailingSlash)
-            url
-        else
-            URLBuilder(url).apply { pathSegments += "" }.build()
-    }
-
+            URLBuilder(this).apply { pathSegments = listOf("") }.build()
+    return if (segments.last() == "")
+        URLBuilder(this).apply { pathSegments = segments.dropLast(2) + "" }.build()
+    else
+        URLBuilder(this).apply { pathSegments = segments.dropLast(1) + "" }.build()
 }
 
 /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/okhttp/OkHttpUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/okhttp/OkHttpUtils.kt
@@ -13,7 +13,7 @@ package at.bitfire.dav4jvm.okhttp
 import okhttp3.HttpUrl
 import okhttp3.Response
 
-@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.KtorHttpUtils"))
+@Deprecated("Migrate to Ktor", ReplaceWith("at.bitfire.dav4jvm.ktor.HttpUtils"))
 object OkHttpUtils {
 
     /**

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/ContentTypeUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/ContentTypeUtilsTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.http.ContentType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContentTypeUtilsTest {
+
+    @Test
+    fun `isText with text plain`() =
+        assertTrue(ContentType.Text.Plain.isText())
+
+    @Test
+    fun `isText with text xml`() =
+        assertTrue(ContentType.Text.Xml.isText())
+
+    @Test
+    fun `isText with application xml`() =
+        assertTrue(ContentType.Application.Xml.isText())
+
+    @Test
+    fun `isText with application json`() =
+        assertFalse(ContentType.Application.Json.isText())
+
+
+    @Test
+    fun `isXml with application xml`() =
+        assertTrue(ContentType.Application.Xml.isXml())
+
+    @Test
+    fun `isXml with text xml`() =
+        assertTrue(ContentType.Text.Xml.isXml())
+
+    @Test
+    fun `isXml with text plain`() =
+        assertFalse(ContentType.Text.Plain.isXml())
+
+
+    @Test
+    fun `toContentTypeOrNull with correct MIME type`() {
+        assertEquals(
+            ContentType.parse("text/x-example"),
+            "text/x-example".toContentTypeOrNull()
+        )
+    }
+
+    @Test
+    fun `toContentTypeOrNull with invalid MIME type`() {
+        assertNull("INVALID".toContentTypeOrNull())
+    }
+
+    @Test
+    fun `toContentTypeOrNull with null`() =
+        assertNull(null.toContentTypeOrNull())
+
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/HttpUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/HttpUtilsTest.kt
@@ -10,23 +10,20 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import at.bitfire.dav4jvm.ktor.KtorHttpUtils.INVALID_STATUS
+import at.bitfire.dav4jvm.ktor.HttpUtils.INVALID_STATUS
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.get
-import io.ktor.http.ContentType
 import io.ktor.http.HeadersBuilder
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class KtorHttpUtilsTest {
+class HttpUtilsTest {
 
     val sampleUrl = Url("http://127.0.0.1")
     private val multipleHeaderValues = "  1,  2 ,3,hyperactive-access"
@@ -46,12 +43,12 @@ class KtorHttpUtilsTest {
 
     @Test
     fun fileName() {
-        assertEquals("", KtorHttpUtils.fileName(Url("https://example.com")))
-        assertEquals("", KtorHttpUtils.fileName(Url("https://example.com/")))
-        assertEquals("file1", KtorHttpUtils.fileName(Url("https://example.com/file1")))
-        assertEquals("dir1", KtorHttpUtils.fileName(Url("https://example.com/dir1/")))
-        assertEquals("file2", KtorHttpUtils.fileName(Url("https://example.com/dir1/file2")))
-        assertEquals("dir2", KtorHttpUtils.fileName(Url("https://example.com/dir1/dir2/")))
+        assertEquals("", HttpUtils.fileName(Url("https://example.com")))
+        assertEquals("", HttpUtils.fileName(Url("https://example.com/")))
+        assertEquals("file1", HttpUtils.fileName(Url("https://example.com/file1")))
+        assertEquals("dir1", HttpUtils.fileName(Url("https://example.com/dir1/")))
+        assertEquals("file2", HttpUtils.fileName(Url("https://example.com/dir1/file2")))
+        assertEquals("dir2", HttpUtils.fileName(Url("https://example.com/dir1/dir2/")))
     }
 
 
@@ -59,7 +56,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with a single header value`() = runTest {
         // Verify that when a header name has a single value, it's returned as a single-element array.
         val httpClient = getMockEngineWithDAVHeaderValues(singleHeaderValue)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(singleHeaderValue, headersArray[0])
         assertEquals(1, headersArray.size)
     }
@@ -68,7 +65,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with multiple comma separated header values`() = runTest {
         // Verify that when a header name has multiple comma-separated values, they are correctly split into an array.
         val httpClient = getMockEngineWithDAVHeaderValues(multipleHeaderValues)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(4, headersArray.size)
         assertEquals("1", headersArray[0])
         assertEquals("2", headersArray[1])
@@ -80,7 +77,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with multiple distinct header entries for the same name`() = runTest {
         // Verify that if the same header name appears multiple times (e.g., 'Set-Cookie'), all values are joined by a comma and then split correctly.
         val httpClient = getMockEngineWithDAVHeaderValues(multipleHeaderValues, singleHeaderValue)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(5, headersArray.size)
         assertEquals("1", headersArray[0])
         assertEquals("2", headersArray[1])
@@ -93,7 +90,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with a header name that does not exist`() = runTest {
         // Verify that when a requested header name is not present in the response, an empty array is returned.
         val httpClient = getMockEngineWithDAVHeaderValues(multipleHeaderValues, singleHeaderValue)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "other")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "other")
         assertEquals(0, headersArray.size)
     }
 
@@ -101,7 +98,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with an empty header value`() = runTest {
         // Verify that if a header exists but its value is an empty string, an empty array is returned (due to filter { it.isNotEmpty() }).
         val httpClient = getMockEngineWithDAVHeaderValues("", "", "")
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(0, headersArray.size)
     }
 
@@ -109,7 +106,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with a header value containing only commas`() = runTest {
         // Verify that if a header value consists only of commas (e.g., ',,,') an empty array is returned.
         val httpClient = getMockEngineWithDAVHeaderValues(",", ",", ",")
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(0, headersArray.size)
     }
 
@@ -118,7 +115,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with header values that are themselves empty after splitting`() = runTest {
         // Verify that if a header value is like 'value1,,value2', the empty string between commas is filtered out, resulting in ['value1', 'value2'].
         val httpClient = getMockEngineWithDAVHeaderValues("   ", singleHeaderValue, ", ")
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "DAV")
         assertEquals(1, headersArray.size)
         assertEquals(singleHeaderValue, headersArray[0])
     }
@@ -127,7 +124,7 @@ class KtorHttpUtilsTest {
     fun `listHeader with a case insensitive header name`() = runTest {
         // HTTP header names are case-insensitive. Verify that `response.headers.getAll(name)` correctly retrieves the header regardless of the casing used for `name` (e.g., 'Content-Type' vs 'content-type').
         val httpClient = getMockEngineWithDAVHeaderValues(singleHeaderValue)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "dav")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "dav")
         assertEquals(singleHeaderValue, headersArray[0])
         assertEquals(1, headersArray.size)
     }
@@ -136,196 +133,117 @@ class KtorHttpUtilsTest {
     fun `listHeader with an empty string as header name`() = runTest {
         // Test what happens if an empty string is passed as the header name. This depends on how `response.headers.getAll` handles empty keys.
         val httpClient = getMockEngineWithDAVHeaderValues(singleHeaderValue)
-        val headersArray = KtorHttpUtils.listHeader(httpClient.get(sampleUrl), "")
+        val headersArray = HttpUtils.listHeader(httpClient.get(sampleUrl), "")
         assertEquals(0, headersArray.size)
     }
 
 
     @Test
     fun `Full status line with HTTP 1 1  200 code  and description`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("HTTP/1.1 200 OK"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("HTTP/1.1 200 OK"))
 
     @Test
     fun `Full status line with HTTP 1 0  404 code  and description`() =
-        assertEquals(HttpStatusCode.NotFound, KtorHttpUtils.parseStatusLine("HTTP/1.0 404 Not Found"))
+        assertEquals(HttpStatusCode.NotFound, HttpUtils.parseStatusLine("HTTP/1.0 404 Not Found"))
 
     @Test
     fun `Full status line with HTTP 2  503 code  and multi word description`() =
-        assertEquals(HttpStatusCode.ServiceUnavailable, KtorHttpUtils.parseStatusLine("HTTP/2 503 Service Unavailable"))
+        assertEquals(HttpStatusCode.ServiceUnavailable, HttpUtils.parseStatusLine("HTTP/2 503 Service Unavailable"))
 
     @Test
     fun `Full status line with HTTP 1 1  200 code  and no description`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("HTTP/1.1 200"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("HTTP/1.1 200"))
 
     @Test
     fun `Partial status line with code and description`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("HTTP/1.1 200 OK"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("HTTP/1.1 200 OK"))
 
     @Test
     fun `Partial status line with code and multi word description`() =
-        assertEquals(HttpStatusCode.NotFound, KtorHttpUtils.parseStatusLine("404 Not Found"))
+        assertEquals(HttpStatusCode.NotFound, HttpUtils.parseStatusLine("404 Not Found"))
 
     @Test
     fun `Partial status line with only code  200`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("200"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("200"))
 
 
     @Test
     fun `Partial status line with only code 404`() =
-        assertEquals(HttpStatusCode.NotFound, KtorHttpUtils.parseStatusLine("404"))
+        assertEquals(HttpStatusCode.NotFound, HttpUtils.parseStatusLine("404"))
 
 
     @Test
     fun `Partial status line with only a known code not having a default description`() =
-        assertEquals(HttpStatusCode(303, ""), KtorHttpUtils.parseStatusLine("303"))
+        assertEquals(HttpStatusCode(303, ""), HttpUtils.parseStatusLine("303"))
 
     @Test
     fun `Partial status line with only an unknown code`() =
-        assertEquals(HttpStatusCode(999, ""), KtorHttpUtils.parseStatusLine("999"))
+        assertEquals(HttpStatusCode(999, ""), HttpUtils.parseStatusLine("999"))
 
     @Test
     fun `Invalid status line   empty string`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine(""))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine(""))
 
 
     @Test
     fun `Invalid status line   just HTTP version`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("HTTP/1.1"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("HTTP/1.1"))
 
     @Test
     fun `Invalid status line   HTTP version and non numeric code`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("HTTP/1.1 ABC OK"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("HTTP/1.1 ABC OK"))
 
     @Test
     fun `Invalid status line   partial with non numeric code`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("ABC OK"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("ABC OK"))
 
     @Test
     fun `Invalid status line   just non numeric text`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("Invalid"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("Invalid"))
 
 
     @Test
     fun `Invalid status line   HTTP version malformed`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("HTTP1.1 200 OK"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("HTTP1.1 200 OK"))
     // Test a status line with a malformed HTTP version: 'HTTP1.1 200 OK'. Expects INVALID_STATUS (as it will be treated as parts.size == 3 but parts[0] doesn't start with 'HTTP/').
 
     @Test
     fun `Invalid status line   status code with leading trailing spaces`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("HTTP/1.1  200  OK"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("HTTP/1.1  200  OK"))
 
     @Test
     fun `Invalid status line   partial code with leading trailing spaces`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine(" 200 "))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine(" 200 "))
 
     @Test
     fun `Status line with extra spaces between code and description`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("HTTP/1.1 200   OK"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("HTTP/1.1 200   OK"))
 
 
     @Test
     fun `Partial status line with extra spaces between code and description`() =
-        assertEquals(HttpStatusCode.OK, KtorHttpUtils.parseStatusLine("200   OK"))
+        assertEquals(HttpStatusCode.OK, HttpUtils.parseStatusLine("200   OK"))
 
     @Test
     fun `Full status line with negative status code`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("HTTP/1.1 -100 Error"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("HTTP/1.1 -100 Error"))
 
 
     @Test
     fun `Partial status line with negative status code`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("-100"))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("-100"))
 
     @Test
     fun `Status line with only spaces`() =
-        assertEquals(INVALID_STATUS, KtorHttpUtils.parseStatusLine("        "))
+        assertEquals(INVALID_STATUS, HttpUtils.parseStatusLine("        "))
 
 
     @Test
     fun `Status line with special characters in description`() =
-        assertEquals(HttpStatusCode(200, "Description with !@#$%^&*()"), KtorHttpUtils.parseStatusLine("HTTP/1.1 200 Description with !@#$%^&*()"))
+        assertEquals(HttpStatusCode(200, "Description with !@#$%^&*()"), HttpUtils.parseStatusLine("HTTP/1.1 200 Description with !@#$%^&*()"))
 
     @Test
     fun `Status line with numeric description only  partial case `() =
-        assertEquals(HttpStatusCode(200, "404"), KtorHttpUtils.parseStatusLine("HTTP/1.1 200 404"))
-
-
-    @Test
-    fun `isText with text plain`() =
-        assertTrue(ContentType.Text.Plain.isText())
-
-    @Test
-    fun `isText with text xml`() =
-        assertTrue(ContentType.Text.Xml.isText())
-
-    @Test
-    fun `isText with application xml`() =
-        assertTrue(ContentType.Application.Xml.isText())
-
-    @Test
-    fun `isText with application json`() =
-        assertFalse(ContentType.Application.Json.isText())
-
-
-    @Test
-    fun `isXml with application xml`() =
-        assertTrue(ContentType.Application.Xml.isXml())
-
-    @Test
-    fun `isXml with text xml`() =
-        assertTrue(ContentType.Text.Xml.isXml())
-
-    @Test
-    fun `isXml with text plain`() =
-        assertFalse(ContentType.Text.Plain.isXml())
-
-
-    @Test
-    fun `toContentTypeOrNull with correct MIME type`() {
-        assertEquals(
-            ContentType.parse("text/x-example"),
-            "text/x-example".toContentTypeOrNull()
-        )
-    }
-
-    @Test
-    fun `toContentTypeOrNull with invalid MIME type`() {
-        assertNull("INVALID".toContentTypeOrNull())
-    }
-
-    @Test
-    fun `toContentTypeOrNull with null`() =
-        assertNull(null.toContentTypeOrNull())
-
-
-    @Test
-    fun `toUrlOrNull with invalid mailto URL`() {
-        assertNull("mailto:invalid".toUrlOrNull())
-    }
-
-    @Test
-    fun `toUrlOrNull with invalid HTTPS URL that can't be decoded`() {
-        assertNull("https://example.com/%f".toUrlOrNull())
-    }
-
-    @Test
-    fun `toUrlOrNull with valid HTTPS URL`() {
-        assertEquals(
-            Url("https://example.com"),
-            "https://example.com".toUrlOrNull()
-        )
-    }
-
-    @Test
-    fun `toUrlOrNull with valid relative URL`() {
-        assertEquals(
-            Url("relative"),
-            "relative".toUrlOrNull()
-        )
-    }
-
-    @Test
-    fun `toUrlOrNull with null`() =
-        assertNull(null.toUrlOrNull())
+        assertEquals(HttpStatusCode(200, "404"), HttpUtils.parseStatusLine("HTTP/1.1 200 404"))
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
@@ -132,4 +132,34 @@ class UrlUtilsTest {
         assertEquals(Url("http://example.org/test"), baseUrl.resolve("http://example.org/test"))
     }
 
+    @Test
+    fun `toUrlOrNull with invalid mailto URL`() {
+        assertNull("mailto:invalid".toUrlOrNull())
+    }
+
+    @Test
+    fun `toUrlOrNull with invalid HTTPS URL that can't be decoded`() {
+        assertNull("https://example.com/%f".toUrlOrNull())
+    }
+
+    @Test
+    fun `toUrlOrNull with valid HTTPS URL`() {
+        assertEquals(
+            Url("https://example.com"),
+            "https://example.com".toUrlOrNull()
+        )
+    }
+
+    @Test
+    fun `toUrlOrNull with valid relative URL`() {
+        assertEquals(
+            Url("relative"),
+            "relative".toUrlOrNull()
+        )
+    }
+
+    @Test
+    fun `toUrlOrNull with null`() =
+        assertNull(null.toUrlOrNull())
+
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
@@ -37,21 +37,47 @@ class UrlUtilsTest {
 
     @Test
     fun testOmitTrailingSlash() {
-        assertEquals(Url("http://host/resource"), UrlUtils.omitTrailingSlash(Url("http://host/resource")))
-        assertEquals(Url("http://host/resource"), UrlUtils.omitTrailingSlash(Url("http://host/resource/")))
-        assertEquals(Url("http://host"), UrlUtils.omitTrailingSlash(Url("http://host")))
-        assertEquals(Url("http://host"), UrlUtils.omitTrailingSlash(Url("http://host/")))
-        assertEquals(Url("http://host/resource?q=1"), UrlUtils.omitTrailingSlash(Url("http://host/resource?q=1")))
-
+        assertEquals(Url("http://host/resource"), Url("http://host/resource").omitTrailingSlash())
+        assertEquals(Url("http://host/resource"), Url("http://host/resource/").omitTrailingSlash())
+        assertEquals(Url("http://host"), Url("http://host").omitTrailingSlash())
+        assertEquals(Url("http://host"), Url("http://host/").omitTrailingSlash())
+        assertEquals(Url("http://host/resource?q=1"), Url("http://host/resource?q=1").omitTrailingSlash())
     }
 
     @Test
     fun testWithTrailingSlash() {
-        assertEquals(Url("http://host/resource/"), UrlUtils.withTrailingSlash(Url("http://host/resource")))
-        assertEquals(Url("http://host/resource/"), UrlUtils.withTrailingSlash(Url("http://host/resource/")))
-        assertEquals(Url("http://host/"), UrlUtils.withTrailingSlash(Url("http://host")))
-        assertEquals(Url("http://host/"), UrlUtils.withTrailingSlash(Url("http://host/")))
-        assertEquals(Url("http://host/resource/?q=1"), UrlUtils.withTrailingSlash(Url("http://host/resource?q=1")))
+        assertEquals(Url("http://host/resource/"), Url("http://host/resource").withTrailingSlash())
+        assertEquals(Url("http://host/resource/"), Url("http://host/resource/").withTrailingSlash())
+        assertEquals(Url("http://host/"), Url("http://host").withTrailingSlash())
+        assertEquals(Url("http://host/"), Url("http://host/").withTrailingSlash())
+        assertEquals(Url("http://host/resource/?q=1"), Url("http://host/resource?q=1").withTrailingSlash())
+    }
+
+    @Test
+    fun testUrl_Parent() {
+        // Root URL - should return itself
+        assertEquals(Url("http://host/"), Url("http://host/").parent())
+        assertEquals(Url("http://host/"), Url("http://host").parent())
+
+        // Single level with trailing slash
+        assertEquals(Url("http://host/"), Url("http://host/folder/").parent())
+
+        // Single level without trailing slash
+        assertEquals(Url("http://host/"), Url("http://host/folder").parent())
+
+        // Multiple levels with trailing slash
+        assertEquals(Url("http://host/folder/"), Url("http://host/folder/subfolder/").parent())
+
+        // Multiple levels without trailing slash
+        assertEquals(Url("http://host/folder/"), Url("http://host/folder/subfolder").parent())
+
+        // Deep nested
+        assertEquals(Url("http://host/a/b/"), Url("http://host/a/b/c/").parent())
+        assertEquals(Url("http://host/a/b/"), Url("http://host/a/b/c").parent())
+
+        // With query parameters
+        assertEquals(Url("http://host/?q=1"), Url("http://host/folder/?q=1").parent())
+        assertEquals(Url("http://host/folder/?q=1"), Url("http://host/folder/subfolder/?q=1").parent())
     }
 
 


### PR DESCRIPTION
Refactors `KtorHttpUtils` to `HttpUtils` with top-level extension functions, following the same pattern as `UrlUtils`. This includes:
- Moving `ContentType` extensions (`isText`, `isXml`) and `String.toContentTypeOrNull()` to `ContentTypeUtils.kt`
- Adding `String.toUrlOrNull()` to `UrlUtils.kt`
- Updating all usages in `DavResource.kt`, `Response.kt`, `ResponseParser.kt`, and `PropStatParser.kt`
- Adding corresponding tests in `ContentTypeUtilsTest.kt` and `UrlUtilsTest.kt`
- Updating deprecation in `OkHttpUtils.kt` to point to `HttpUtils`