### PR TITLE
[ktor] Add `DomainAuthProvider`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,12 +58,12 @@ dependencies {
     api(libs.spotbugs.annotations)
     api(libs.xpp3)
 
+    implementation(libs.ktor.client.auth)
     implementation(libs.ktor.client.encoding)
     implementation(libs.ktor.client.core)
 
     testImplementation(libs.junit4)
     testImplementation(libs.kotlin.coroutines.test)
-    testImplementation(libs.ktor.client.auth)
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.okhttp.mockwebserver)
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainAuthProvider.kt
@@ -19,14 +19,14 @@ import io.ktor.http.isSecure
 /**
  * An [AuthProvider] wrapper that can limit authentication to a given domain.
  *
- * @param domain Credentials will only be set on requests to this domain and its subdomains. If `null`, setting
- *   credentials is not restricted by the request's domain.
+ * @param firstLevelDomain Credentials will only be set on requests to this first-level domain and its subdomains.
+ *   If `null`, setting credentials is not restricted by the request's domain.
  * @param insecurePreemptive If `true`, credentials will be set on initial requests even if a non-secure protocol is
  *   used. Otherwise, credentials are only sent after having received a `WWW-Authenticate` response header.
  * @param authProviderDelegate The [AuthProvider] to delegate to.
  */
 class DomainAuthProvider(
-    private val domain: String?,
+    private val firstLevelDomain: String?,
     private val insecurePreemptive: Boolean,
 
     private val authProviderDelegate: AuthProvider
@@ -47,7 +47,7 @@ class DomainAuthProvider(
     }
 
     private fun isDomainMatch(request: HttpRequestBuilder): Boolean {
-        return domain == null || domain.equals(hostToDomain(request.url.host), ignoreCase = true)
+        return firstLevelDomain == null || firstLevelDomain.equals(hostToDomain(request.url.host), ignoreCase = true)
     }
 
     private fun isPreemptivePolicyMet(request: HttpRequestBuilder): Boolean {

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainAuthProvider.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import at.bitfire.dav4jvm.ktor.UrlUtils.hostToDomain
+import io.ktor.client.plugins.auth.AuthProvider
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.isSecure
+
+/**
+ * An [AuthProvider] wrapper that can limit authentication to a given domain.
+ *
+ * @param domain Credentials will only be set on requests to this domain and its subdomains. If `null`, setting
+ *   credentials is not restricted by the request's domain.
+ * @param insecurePreemptive If `true`, credentials will be set on initial requests even if a non-secure protocol is
+ *   used. Otherwise, credentials are only sent after having received a `WWW-Authenticate` response header.
+ * @param authProviderDelegate The [AuthProvider] to delegate to.
+ */
+class DomainAuthProvider(
+    private val domain: String?,
+    private val insecurePreemptive: Boolean,
+
+    private val authProviderDelegate: AuthProvider
+) : AuthProvider by authProviderDelegate {
+
+    override suspend fun addRequestHeaders(request: HttpRequestBuilder, authHeader: HttpAuthHeader?) {
+        if (isDomainMatch(request)) {
+            authProviderDelegate.addRequestHeaders(request, authHeader)
+        }
+    }
+
+    override fun sendWithoutRequest(request: HttpRequestBuilder): Boolean {
+        return if (isPreemptivePolicyMet(request) && isDomainMatch(request)) {
+            authProviderDelegate.sendWithoutRequest(request)
+        } else {
+            false
+        }
+    }
+
+    private fun isDomainMatch(request: HttpRequestBuilder): Boolean {
+        return domain == null || domain.equals(hostToDomain(request.url.host), ignoreCase = true)
+    }
+
+    private fun isPreemptivePolicyMet(request: HttpRequestBuilder): Boolean {
+        return insecurePreemptive || request.url.protocol.isSecure()
+    }
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProvider.kt
@@ -24,7 +24,7 @@ import io.ktor.client.plugins.auth.providers.BasicAuthProvider
  *         createDomainBasicAuthProvider(
  *             username = "user",
  *             password = "password",
- *             domain = "domain.example",
+ *             firstLevelDomain = "domain.example",
  *         )
  *     )
  * }
@@ -33,7 +33,7 @@ import io.ktor.client.plugins.auth.providers.BasicAuthProvider
 fun createDomainBasicAuthProvider(
     username: String,
     password: String,
-    domain: String? = null,
+    firstLevelDomain: String? = null,
     insecurePreemptive: Boolean = false,
 ): DomainAuthProvider {
     val basicAuthProvider = BasicAuthProvider(
@@ -41,5 +41,5 @@ fun createDomainBasicAuthProvider(
         sendWithoutRequestCallback = { true }
     )
 
-    return DomainAuthProvider(domain, insecurePreemptive, basicAuthProvider)
+    return DomainAuthProvider(firstLevelDomain, insecurePreemptive, basicAuthProvider)
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProvider.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.client.plugins.auth.AuthProvider
+import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
+import io.ktor.client.plugins.auth.providers.BasicAuthProvider
+
+/**
+ * Creates an [AuthProvider] to manage Basic authentication against a given service.
+ *
+ * Usage:
+ * ```
+ * install(Auth) {
+ *     providers.add(
+ *         createDomainBasicAuthProvider(
+ *             username = "user",
+ *             password = "password",
+ *             domain = "domain.example",
+ *         )
+ *     )
+ * }
+ * ```
+ */
+fun createDomainBasicAuthProvider(
+    username: String,
+    password: String,
+    domain: String? = null,
+    insecurePreemptive: Boolean = false,
+): DomainAuthProvider {
+    val basicAuthProvider = BasicAuthProvider(
+        credentials = { BasicAuthCredentials(username, password) },
+        sendWithoutRequestCallback = { true }
+    )
+
+    return DomainAuthProvider(domain, insecurePreemptive, basicAuthProvider)
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProvider.kt
@@ -24,7 +24,7 @@ import io.ktor.client.plugins.auth.providers.DigestAuthProvider
  *         createDomainDigestAuthProvider(
  *             username = "user",
  *             password = "password",
- *             domain = "domain.example",
+ *             firstLevelDomain = "domain.example",
  *         )
  *     )
  * }
@@ -33,11 +33,11 @@ import io.ktor.client.plugins.auth.providers.DigestAuthProvider
 fun createDomainDigestAuthProvider(
     username: String,
     password: String,
-    domain: String? = null,
+    firstLevelDomain: String? = null,
 ): DomainAuthProvider {
     val digestAuthProvider = DigestAuthProvider(
         credentials = { DigestAuthCredentials(username, password) }
     )
 
-    return DomainAuthProvider(domain, insecurePreemptive = false, digestAuthProvider)
+    return DomainAuthProvider(firstLevelDomain, insecurePreemptive = false, digestAuthProvider)
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProvider.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.client.plugins.auth.AuthProvider
+import io.ktor.client.plugins.auth.providers.DigestAuthCredentials
+import io.ktor.client.plugins.auth.providers.DigestAuthProvider
+
+/**
+ * Creates an [AuthProvider] to manage Digest authentication against a given service.
+ *
+ * Usage:
+ * ```
+ * install(Auth) {
+ *     providers.add(
+ *         createDomainDigestAuthProvider(
+ *             username = "user",
+ *             password = "password",
+ *             domain = "domain.example",
+ *         )
+ *     )
+ * }
+ * ```
+ */
+fun createDomainDigestAuthProvider(
+    username: String,
+    password: String,
+    domain: String? = null,
+): DomainAuthProvider {
+    val digestAuthProvider = DigestAuthProvider(
+        credentials = { DigestAuthCredentials(username, password) }
+    )
+
+    return DomainAuthProvider(domain, insecurePreemptive = false, digestAuthProvider)
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProviderTest.kt
@@ -28,7 +28,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = null
+            firstLevelDomain = null
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -45,7 +45,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -62,7 +62,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -79,7 +79,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -96,7 +96,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -113,7 +113,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = null
+            firstLevelDomain = null
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTP
@@ -130,7 +130,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = null
+            firstLevelDomain = null
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -147,7 +147,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = null,
+            firstLevelDomain = null,
             insecurePreemptive = false
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
@@ -165,7 +165,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = null,
+            firstLevelDomain = null,
             insecurePreemptive = true
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
@@ -183,7 +183,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -200,7 +200,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -217,7 +217,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS
@@ -234,7 +234,7 @@ class DomainBasicAuthProviderTest {
         val authProvider = createDomainBasicAuthProvider(
             username = "user",
             password = "password",
-            domain = "domain.example"
+            firstLevelDomain = "domain.example"
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainBasicAuthProviderTest.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLProtocol
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// Note: This mostly tests the functionality of DomainAuthProvider
+class DomainBasicAuthProviderTest {
+
+    @Test
+    fun `addRequestHeaders() with domain not set`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==", httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `addRequestHeaders() with request hostname equal to domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==", httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `addRequestHeaders() with request hostname case-insensitively matching domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "DOMAIN.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==", httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `addRequestHeaders() with request hostname being a subdomain of domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "subdomain.domain.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==", httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `addRequestHeaders() with request hostname not matching domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "other-domain.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertNull(httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `addRequestHeaders() with insecure protocol`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTP
+            url.host = "domain.example"
+        }
+
+        authProvider.addRequestHeaders(httpRequestBuilder)
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==", httpRequestBuilder.headers[HttpHeaders.Authorization])
+    }
+
+    @Test
+    fun `sendWithoutRequest() without domain set`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with insecure protocol and insecurePreemptive=false`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null,
+            insecurePreemptive = false
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTP
+            url.host = "domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with insecure protocol and insecurePreemptive=true`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null,
+            insecurePreemptive = true
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTP
+            url.host = "domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with request hostname equal to domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with request hostname case-insensitively matching domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "DOMAIN.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with request hostname being a subdomain of domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "subdomain.domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `sendWithoutRequest() with request hostname not matching domain`() = runTest {
+        val authProvider = createDomainBasicAuthProvider(
+            username = "user",
+            password = "password",
+            domain = "domain.example"
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "other-domain.example"
+        }
+
+        val result = authProvider.sendWithoutRequest(httpRequestBuilder)
+
+        assertFalse(result)
+    }
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProviderTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLProtocol
+import io.ktor.http.auth.parseAuthorizationHeader
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DomainDigestAuthProviderTest {
+
+    @Test
+    fun happyPath() = runTest {
+        val authProvider = createDomainDigestAuthProvider(
+            username = "user",
+            password = "password",
+            domain = null
+        )
+        val httpRequestBuilder = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+        val authHeader = parseAuthorizationHeader("""Digest algorithm=MD5, realm="realm", nonce="md5-nonce"""")!!
+
+        // Note: isApplicable() needs to be called before addRequestHeaders()
+        val isApplicable = authProvider.isApplicable(authHeader)
+
+        assertTrue(isApplicable)
+
+        authProvider.addRequestHeaders(httpRequestBuilder, authHeader)
+
+        assertTrue("""nonce="md5-nonce"""" in httpRequestBuilder.headers[HttpHeaders.Authorization]!!)
+    }
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DomainDigestAuthProviderTest.kt
@@ -25,7 +25,7 @@ class DomainDigestAuthProviderTest {
         val authProvider = createDomainDigestAuthProvider(
             username = "user",
             password = "password",
-            domain = null
+            firstLevelDomain = null
         )
         val httpRequestBuilder = HttpRequestBuilder().apply {
             url.protocol = URLProtocol.HTTPS


### PR DESCRIPTION
Use ktor's authentication mechanism and extend it to allow limiting authentication to a given domain.

Part of https://github.com/bitfireAT/davx5-ose/issues/2587