### PR TITLE
Handle IP addresses in hostToDomain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ tasks.withType<DokkaTask>().configureEach {
 }
 
 dependencies {
+    api(libs.guava)
     api(libs.okhttp)
     api(libs.spotbugs.annotations)
     api(libs.xpp3)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,13 +54,13 @@ tasks.withType<DokkaTask>().configureEach {
 }
 
 dependencies {
-    api(libs.guava)
     api(libs.okhttp)
-    api(libs.spotbugs.annotations)
     api(libs.xpp3)
 
+    implementation(libs.guava)
     implementation(libs.ktor.client.encoding)
     implementation(libs.ktor.client.core)
+    implementation(libs.spotbugs.annotations)
 
     testImplementation(libs.junit4)
     testImplementation(libs.kotlin.coroutines.test)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 dokka = "2.2.0"
+guava = "33.6.0-jre"
 junit4 = "4.13.2"
 # don't upgrade to Kotlin 2.4 until Hilt > 2.59.2 fixes the metadata problem (https://github.com/google/dagger/issues/5177)
 kotlin = "2.3.21"
@@ -10,6 +11,7 @@ xpp3Version = "1.1.6"
 ktor = "3.5.1"
 
 [libraries]
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
@@ -29,11 +29,11 @@ object UrlUtils {
         if (host == null)
             return null
 
-        if (InetAddresses.isInetAddress(host))
-            return host
-
         // remove optional dot at end
         val withoutTrailingDot = host.removeSuffix(".")
+
+        if (InetAddresses.isInetAddress(withoutTrailingDot))
+            return withoutTrailingDot
 
         // split into labels
         val labels = withoutTrailingDot.split('.')

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/UrlUtils.kt
@@ -10,10 +10,8 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import io.ktor.http.URLBuilder
-import io.ktor.http.URLParserException
-import io.ktor.http.Url
-import io.ktor.http.takeFrom
+import com.google.common.net.InetAddresses
+import io.ktor.http.*
 
 object UrlUtils {
 
@@ -21,13 +19,18 @@ object UrlUtils {
      * Gets the first-level domain name (without subdomains) from a host name.
      * Also removes trailing dots.
      *
-     * @param host name (e.g. `www.example.com.`)
+     * If [host] is an IP address, it's returned unchanged.
      *
-     * @return domain name (e.g. `example.com`)
+     * @param host name (e.g. `www.example.com.`) or IP address
+     *
+     * @return domain name (e.g. `example.com`) or unchanged IP address
      */
     fun hostToDomain(host: String?): String? {
         if (host == null)
             return null
+
+        if (InetAddresses.isInetAddress(host))
+            return host
 
         // remove optional dot at end
         val withoutTrailingDot = host.removeSuffix(".")

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
@@ -33,11 +33,11 @@ class UrlUtilsTest {
     }
 
     @Test
-    fun `testHostToDomain does not truncate IPv4 addresses`() {
+    fun `testHostToDomain does not truncate IP addresses`() {
         assertEquals("127.0.0.1", UrlUtils.hostToDomain("127.0.0.1"))
-        assertEquals("10.20.0.1", UrlUtils.hostToDomain("10.20.0.1"))
-        assertEquals("192.168.0.1", UrlUtils.hostToDomain("192.168.0.1"))
-        assertNotEquals(UrlUtils.hostToDomain("10.20.0.1"), UrlUtils.hostToDomain("192.168.0.1"))
+        assertEquals("127.0.0.1", UrlUtils.hostToDomain("127.0.0.1."))
+        assertEquals("2001:db8::1", UrlUtils.hostToDomain("2001:db8::1"))
+        assertEquals("[2001:db8::1]", UrlUtils.hostToDomain("[2001:db8::1]"))
     }
 
     @Test

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/UrlUtilsTest.kt
@@ -10,11 +10,8 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import io.ktor.http.Url
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import io.ktor.http.*
+import org.junit.Assert.*
 import org.junit.Test
 
 class UrlUtilsTest {
@@ -33,6 +30,14 @@ class UrlUtilsTest {
         assertEquals("example.com", UrlUtils.hostToDomain("host.example.com."))
         assertEquals("example.com", UrlUtils.hostToDomain("sub.host.example.com"))
         assertEquals("example.com", UrlUtils.hostToDomain("sub.host.example.com."))
+    }
+
+    @Test
+    fun `testHostToDomain does not truncate IPv4 addresses`() {
+        assertEquals("127.0.0.1", UrlUtils.hostToDomain("127.0.0.1"))
+        assertEquals("10.20.0.1", UrlUtils.hostToDomain("10.20.0.1"))
+        assertEquals("192.168.0.1", UrlUtils.hostToDomain("192.168.0.1"))
+        assertNotEquals(UrlUtils.hostToDomain("10.20.0.1"), UrlUtils.hostToDomain("192.168.0.1"))
     }
 
     @Test


### PR DESCRIPTION
Uses Guava to determine IP addresses in `hostToDomain`.

Without this PR, both `127.0.0.1` and `4.3.2.1` are resolved to `domain = "1"` and thus credentials that are only intended for `127.0.0.1` are also sent to `4.3.2.1`.