### PR TITLE
Add Accept header to WebDAV XML requests

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -25,8 +25,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
-import java.util.logging.Logger
 import java.io.StringWriter
+import java.util.logging.Logger
 
 class DavAddressBook(
     httpClient: HttpClient,
@@ -73,6 +73,7 @@ class DavAddressBook(
 
                 header(HttpHeaders.Depth, "1")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
@@ -141,6 +142,7 @@ class DavAddressBook(
 
                 header(HttpHeaders.Depth, "0")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -16,16 +16,22 @@ import at.bitfire.dav4jvm.XmlUtils.insertTag
 import at.bitfire.dav4jvm.property.caldav.CalDAV
 import at.bitfire.dav4jvm.property.caldav.CalendarData
 import at.bitfire.dav4jvm.property.webdav.WebDAV
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-import java.util.logging.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.prepareRequest
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.Url
+import io.ktor.http.contentType
 import java.io.StringWriter
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import java.util.logging.Logger
 
 @Suppress("unused")
 class DavCalendar(
@@ -109,6 +115,7 @@ class DavCalendar(
 
                 header(HttpHeaders.Depth, "1")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
@@ -175,6 +182,7 @@ class DavCalendar(
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -22,8 +22,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
-import java.util.logging.Logger
 import java.io.StringWriter
+import java.util.logging.Logger
 
 /**
  * Represents a WebDAV collection.
@@ -100,6 +100,7 @@ open class DavCollection @JvmOverloads constructor(
 
                 header(HttpHeaders.Depth, "0")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -264,9 +264,7 @@ open class DavResource(
      * Because the target [location] is by definition a collection, a trailing slash
      * is appended (unless [location] already has a trailing slash).
      *
-     * @param xmlBody           optional request body (used for MKCALENDAR or Extended MKCOL);
-     *                          if set, `Accept: application/xml, text/xml` is sent because the
-     *                          server may return a Multi-Status response body
+     * @param xmlBody           optional request body (used for MKCALENDAR or Extended MKCOL)
      * @param methodName        HTTP MKCOL method (`MKCOL` by default, may for instance be `MKCALENDAR`)
      * @param additionalHeaders additional headers to send with the request
      * @param callback          called with server response on success
@@ -288,8 +286,8 @@ open class DavResource(
                 if (additionalHeaders != null)
                     headers.appendAll(additionalHeaders)
 
+                acceptXml()
                 if (xmlBody != null) {
-                    acceptXml()
                     contentType(MIME_XML_UTF8)
                     setBody(xmlBody)
                 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -22,6 +22,8 @@ import at.bitfire.dav4jvm.property.carddav.CardDAV
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import io.ktor.client.HttpClient
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.accept
 import io.ktor.client.request.header
 import io.ktor.client.request.prepareDelete
 import io.ktor.client.request.prepareGet
@@ -262,7 +264,9 @@ open class DavResource(
      * Because the target [location] is by definition a collection, a trailing slash
      * is appended (unless [location] already has a trailing slash).
      *
-     * @param xmlBody           optional request body (used for MKCALENDAR or Extended MKCOL)
+     * @param xmlBody           optional request body (used for MKCALENDAR or Extended MKCOL);
+     *                          if set, `Accept: application/xml, text/xml` is sent because the
+     *                          server may return a Multi-Status response body
      * @param methodName        HTTP MKCOL method (`MKCOL` by default, may for instance be `MKCALENDAR`)
      * @param additionalHeaders additional headers to send with the request
      * @param callback          called with server response on success
@@ -285,6 +289,7 @@ open class DavResource(
                     headers.appendAll(additionalHeaders)
 
                 if (xmlBody != null) {
+                    acceptXml()
                     contentType(MIME_XML_UTF8)
                     setBody(xmlBody)
                 }
@@ -503,6 +508,7 @@ open class DavResource(
 
                 header(HttpHeaders.Depth, if (depth >= 0) depth.toString() else "infinity")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
@@ -538,6 +544,7 @@ open class DavResource(
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("PROPPATCH")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(rqBody)
             }
@@ -568,6 +575,7 @@ open class DavResource(
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("SEARCH")
 
+                acceptXml()
                 contentType(MIME_XML_UTF8)
                 setBody(search)
             }
@@ -740,6 +748,20 @@ open class DavResource(
         } catch (e: XmlPullParserException) {
             throw DavException("Couldn't parse multistatus XML element", cause = e)
         }
+    }
+
+
+    // request building
+
+    /**
+     * Adds an `Accept` header for XML request/response bodies, as sent by WebDAV methods
+     * that expect an XML (Multi-Status) response, like PROPFIND, PROPPATCH, REPORT and SEARCH.
+     *
+     * Per RFC 4918 8.2, servers MUST accept both `application/xml` and `text/xml`.
+     */
+    protected fun HttpRequestBuilder.acceptXml() {
+        accept(ContentType.Application.Xml)
+        accept(ContentType.Text.Xml)
     }
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
@@ -56,6 +56,15 @@ class DavAddressBookTest {
     }
 
     @Test
+    fun `addressbookQuery sends headers`() = runTest {
+        val engine = minimalMultiStatus()
+        davAddressBook(engine).addressbookQuery { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
+    }
+
+    @Test
     fun `addressbookQuery request body contains query and filter`() = runTest {
         val engine = minimalMultiStatus()
         davAddressBook(engine).addressbookQuery { _, _ -> }
@@ -72,6 +81,15 @@ class DavAddressBookTest {
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
+        }
+    }
+
+    @Test
+    fun `multiget sends headers`() = runTest {
+        val engine = minimalMultiStatus()
+        davAddressBook(engine).multiget(listOf(sampleUrl)) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
@@ -46,20 +46,13 @@ class DavAddressBookTest {
 
 
     @Test
-    fun `addressbookQuery sends REPORT with Depth 1`() = runTest {
+    fun `addressbookQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
         davAddressBook(engine).addressbookQuery { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
-        }
-    }
-
-    @Test
-    fun `addressbookQuery sends headers`() = runTest {
-        val engine = minimalMultiStatus()
-        davAddressBook(engine).addressbookQuery { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
@@ -75,20 +68,13 @@ class DavAddressBookTest {
     }
 
     @Test
-    fun `multiget sends REPORT with Depth 0`() = runTest {
+    fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
         davAddressBook(engine).multiget(listOf(sampleUrl)) { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
-        }
-    }
-
-    @Test
-    fun `multiget sends headers`() = runTest {
-        val engine = minimalMultiStatus()
-        davAddressBook(engine).multiget(listOf(sampleUrl)) { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
@@ -101,39 +101,25 @@ class DavCalendarTest {
     }
 
     @Test
-    fun `calendarQuery sends REPORT with Depth 1`() = runTest {
+    fun `calendarQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
         davCalendar(engine).calendarQuery("VEVENT", start = null, end = null) { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
-        }
-    }
-
-    @Test
-    fun `calendarQuery sends headers`() = runTest {
-        val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null) { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
 
     @Test
-    fun `multiget sends REPORT without Depth header`() = runTest {
+    fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
         davCalendar(engine).multiget(listOf(sampleUrl)) { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertNull(headers[HttpHeaders.Depth])
-        }
-    }
-
-    @Test
-    fun `multiget sends headers`() = runTest {
-        val engine = minimalMultiStatus()
-        davCalendar(engine).multiget(listOf(sampleUrl)) { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
@@ -111,12 +111,30 @@ class DavCalendarTest {
     }
 
     @Test
+    fun `calendarQuery sends headers`() = runTest {
+        val engine = minimalMultiStatus()
+        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
+    }
+
+    @Test
     fun `multiget sends REPORT without Depth header`() = runTest {
         val engine = minimalMultiStatus()
         davCalendar(engine).multiget(listOf(sampleUrl)) { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertNull(headers[HttpHeaders.Depth])
+        }
+    }
+
+    @Test
+    fun `multiget sends headers`() = runTest {
+        val engine = minimalMultiStatus()
+        davCalendar(engine).multiget(listOf(sampleUrl)) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
@@ -257,20 +257,13 @@ class DavCollectionTest {
     }
 
     @Test
-    fun `reportChanges sends REPORT with Depth 0`() = runTest {
+    fun `reportChanges sends proper request`() = runTest {
         val engine = minimalMultiStatus()
         davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
-        }
-    }
-
-    @Test
-    fun `reportChanges sends headers`() = runTest {
-        val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
@@ -267,6 +267,15 @@ class DavCollectionTest {
     }
 
     @Test
+    fun `reportChanges sends headers`() = runTest {
+        val engine = minimalMultiStatus()
+        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
+    }
+
+    @Test
     fun `reportChanges null sync token sends empty sync-token element`() = runTest {
         val engine = minimalMultiStatus()
         davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -408,6 +408,15 @@ class DavResourceTest {
     }
 
     @Test
+    fun `mkCol xmlBody sends headers`() = runTest {
+        val engine = mockEngine(HttpStatusCode.Created)
+        davResource(engine).mkCol("<mkcalendar/>") { }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
+    }
+
+    @Test
     fun `options with capabilities`() = runTest {
         val engine = MockEngine {
             respond("", HttpStatusCode.OK, HeadersBuilder().apply { append("DAV", "  1,  2 ,3,hyperactive-access") }.build())
@@ -783,6 +792,15 @@ class DavResourceTest {
     }
 
     @Test
+    fun `propfind sends headers`() = runTest {
+        val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
+        davResource(engine).propfind(0, WebDAV.ResourceType) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
+    }
+
+    @Test
     fun `proppatch response with propstat`() = runTest {
         val dav = davResource(
             propfindEngine(
@@ -825,6 +843,15 @@ class DavResourceTest {
                     "<d:remove><d:prop><n2:removeThis xmlns:n2=\"sample\" /></d:prop></d:remove>" +
                     "</d:propertyupdate>", xml
         )
+    }
+
+    @Test
+    fun `proppatch sends headers`() = runTest {
+        val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
+        davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()) { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+        }
     }
 
     @Test
@@ -914,6 +941,15 @@ class DavResourceTest {
             assertEquals(HttpMethod.parse("SEARCH"), method)
             assertEquals(sampleUrl.encodedPath, url.encodedPath)
             assertEquals("<TEST/>", (body as TextContent).text)
+        }
+    }
+
+    @Test
+    fun `search sends headers`() = runTest {
+        val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
+        davResource(engine).search("<TEST/>") { _, _ -> }
+        with(engine.requestHistory.last()) {
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -48,6 +48,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
 
+/*
+ * For every request-sending method, at least one test should verify:
+ *
+ * - the request method
+ * - the request headers, including Accept (application/xml, text/xml if an XML response is
+ *   expected; otherwise whatever applies) and Content-Type (if a body is sent)
+ *
+ * Other tests for the same method only need to assert a header if its expected value differs
+ * from that default.
+ */
 class DavResourceTest {
 
     private val sampleText = "SAMPLE RESPONSE"
@@ -106,7 +116,6 @@ class DavResourceTest {
         dav.copy(sampleDestination, true) { called = true }
         assertTrue(called)
         with(engine.requestHistory.last()) {
-            assertEquals(HttpMethod.parse("COPY"), method)
             assertEquals(sampleDestination.toString(), headers[HttpHeaders.Destination])
             assertNull(headers[HttpHeaders.Overwrite])
         }
@@ -273,6 +282,7 @@ class DavResourceTest {
         val dav = davResource(engine)
         var called = false
         dav.getRange(100, 342) { response ->
+            assertEquals(HttpMethod.Get, response.request.method)
             assertEquals("bytes=100-441", response.request.headers[HttpHeaders.Range])
             called = true
         }
@@ -364,7 +374,6 @@ class DavResourceTest {
         assertTrue(called)
         assertEquals(sampleDestination, dav.location)
         with(engine.requestHistory.last()) {
-            assertEquals(HttpMethod.parse("MOVE"), method)
             assertEquals(sampleDestination.toString(), headers[HttpHeaders.Destination])
             assertNull(headers[HttpHeaders.Overwrite])
         }
@@ -404,14 +413,17 @@ class DavResourceTest {
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("MKCOL"), method)
             assertNull(headers[HttpHeaders.ContentType])
+            assertEquals("*/*", headers[HttpHeaders.Accept])
         }
     }
 
     @Test
-    fun `mkCol xmlBody sends headers`() = runTest {
+    fun `mkCol xmlBody sends proper request`() = runTest {
         val engine = mockEngine(HttpStatusCode.Created)
         davResource(engine).mkCol("<mkcalendar/>") { }
         with(engine.requestHistory.last()) {
+            assertEquals(HttpMethod.parse("MKCOL"), method)
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
@@ -431,7 +443,11 @@ class DavResourceTest {
             assertTrue(davCapabilities.any { it.contains("hyperactive-access") })
         }
         assertTrue(called)
-        assertEquals("identity", engine.requestHistory.last().headers[HttpHeaders.AcceptEncoding])
+        with(engine.requestHistory.last()) {
+            assertEquals(HttpMethod.Options, method)
+            assertEquals("0", headers[HttpHeaders.ContentLength])
+            assertEquals("identity", headers[HttpHeaders.AcceptEncoding])
+        }
     }
 
     @Test
@@ -792,10 +808,13 @@ class DavResourceTest {
     }
 
     @Test
-    fun `propfind sends headers`() = runTest {
+    fun `propfind sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
         davResource(engine).propfind(0, WebDAV.ResourceType) { _, _ -> }
         with(engine.requestHistory.last()) {
+            assertEquals(HttpMethod.parse("PROPFIND"), method)
+            assertEquals("0", headers[HttpHeaders.Depth])
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
@@ -846,10 +865,12 @@ class DavResourceTest {
     }
 
     @Test
-    fun `proppatch sends headers`() = runTest {
+    fun `proppatch sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
         davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()) { _, _ -> }
         with(engine.requestHistory.last()) {
+            assertEquals(HttpMethod.parse("PROPPATCH"), method)
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
@@ -940,16 +961,9 @@ class DavResourceTest {
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("SEARCH"), method)
             assertEquals(sampleUrl.encodedPath, url.encodedPath)
-            assertEquals("<TEST/>", (body as TextContent).text)
-        }
-    }
-
-    @Test
-    fun `search sends headers`() = runTest {
-        val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
-        davResource(engine).search("<TEST/>") { _, _ -> }
-        with(engine.requestHistory.last()) {
+            assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
             assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
+            assertEquals("<TEST/>", (body as TextContent).text)
         }
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -404,7 +404,7 @@ class DavResourceTest {
     }
 
     @Test
-    fun `mkCol null body sends no Content-Type`() = runTest {
+    fun `mkCol null body sends proper request`() = runTest {
         val engine = mockEngine(HttpStatusCode.Created)
         val dav = davResource(engine)
         var called = false
@@ -413,7 +413,7 @@ class DavResourceTest {
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("MKCOL"), method)
             assertNull(headers[HttpHeaders.ContentType])
-            assertEquals("*/*", headers[HttpHeaders.Accept])
+            assertEquals(listOf("application/xml", "text/xml"), headers.getAll(HttpHeaders.Accept))
         }
     }
 


### PR DESCRIPTION
Adds `Accept: application/xml, text/xml` to WebDAV requests that expect an XML response (PROPFIND, PROPPATCH, REPORT, SEARCH, and MKCOL/MKCALENDAR with a body), as required by WebDAV RFC.

Also unifies how outgoing request method/headers are verified in the ktor test suite.

Closes bitfireAT/dav4jvm#196
Related: bitfireAT/davx5-ose#2623