### PR TITLE
Simplify `followRedirect` (callback → suspending typed block)

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -66,8 +66,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        var result: List<Property>? = null
-        followRedirects({
+        return followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -78,9 +77,8 @@ class DavAddressBook(
                 setBody(writer.toString())
             }
         }) { response ->
-            result = processMultiStatus(response, callback)
+            processMultiStatus(response, callback)
         }
-        return result ?: emptyList()
     }
 
     /**
@@ -135,8 +133,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        var result: List<Property>? = null
-        followRedirects({
+        return followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -147,9 +144,8 @@ class DavAddressBook(
                 setBody(writer.toString())
             }
         }) { response ->
-            result = processMultiStatus(response, callback)
+            processMultiStatus(response, callback)
         }
-        return result ?: emptyList()
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -108,8 +108,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        var result: List<Property>? = null
-        followRedirects({
+        return followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -120,9 +119,8 @@ class DavCalendar(
                 setBody(writer.toString())
             }
         }) { response ->
-            result = processMultiStatus(response, callback)
+            processMultiStatus(response, callback)
         }
-        return result ?: emptyList()
     }
 
     /**
@@ -177,8 +175,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        var result: List<Property>? = null
-        followRedirects({
+        return followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -187,9 +184,8 @@ class DavCalendar(
                 setBody(writer.toString())
             }
         }) { response ->
-            result = processMultiStatus(response, callback)
+            processMultiStatus(response, callback)
         }
-        return result ?: emptyList()
     }
 
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -93,8 +93,7 @@ open class DavCollection @JvmOverloads constructor(
         }
         serializer.endDocument()
 
-        var result: List<Property>? = null
-        followRedirects({
+        return followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -105,9 +104,8 @@ open class DavCollection @JvmOverloads constructor(
                 setBody(writer.toString())
             }
         }) { response ->
-            result = processMultiStatus(response, callback)
+            processMultiStatus(response, callback)
         }
-        return result ?: emptyList()
     }
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -601,6 +601,16 @@ open class DavResource(
     }
 
     /**
+     * Outcome of a single [followRedirects] hop: either the server redirected us to
+     * [Redirected.destination] (follow up with another request), or we're [Done] with the final
+     * value produced by the caller's block.
+     */
+    private sealed class RedirectOutcome<out T> {
+        data class Redirected(val destination: Url) : RedirectOutcome<Nothing>()
+        data class Done<T>(val value: T) : RedirectOutcome<T>()
+    }
+
+    /**
      * Sends a request and follows up to [MAX_REDIRECTS] redirects.
      *
      * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
@@ -613,44 +623,48 @@ open class DavResource(
     internal suspend fun <T> followRedirects(
         prepareRequest: suspend () -> HttpStatement,
         block: suspend (HttpResponse) -> T
-    ): T =
-        followRedirects(prepareRequest, redirectCount = 0, block)
+    ): T {
+        var redirectCount = 0
+        while (true) {
+            val outcome = prepareRequest().execute { response ->
+                val isRedirect = response.status in arrayOf(
+                    HttpStatusCode.MovedPermanently,
+                    HttpStatusCode.Found,
+                    HttpStatusCode.TemporaryRedirect,
+                    HttpStatusCode.PermanentRedirect
+                )
+                if (isRedirect) {
+                    if (redirectCount + 1 >= MAX_REDIRECTS)
+                        throw DavException("Too many redirects")
 
-    private suspend fun <T> followRedirects(
-        prepareRequest: suspend () -> HttpStatement,
-        redirectCount: Int,
-        block: suspend (HttpResponse) -> T
-    ): T =
-        prepareRequest().execute { response ->
-            val isRedirect = response.status in arrayOf(
-                HttpStatusCode.MovedPermanently,
-                HttpStatusCode.Found,
-                HttpStatusCode.TemporaryRedirect,
-                HttpStatusCode.PermanentRedirect
-            )
-            if (isRedirect) {
-                if (redirectCount + 1 >= MAX_REDIRECTS)
-                    throw DavException("Too many redirects")
+                    // take new location from response header
+                    val newLocation = response.headers[HttpHeaders.Location]
+                        ?: throw DavException("Redirected without new Location")
 
-                // take new location from response header
-                val newLocation = response.headers[HttpHeaders.Location]
-                    ?: throw DavException("Redirected without new Location")
+                    // resolve possible relative location URL
+                    val destination = location.resolve(newLocation)
+                        ?: throw DavException("Redirected to invalid Location")
 
-                // resolve possible relative location URL
-                val destination = location.resolve(newLocation)
-                    ?: throw DavException("Redirected to invalid Location")
+                    // block insecure redirects
+                    if (location.protocol.isSecure() && !destination.protocol.isSecure())
+                        throw DavException("Received redirect from HTTPS to HTTP")
 
-                // block insecure redirects
-                if (location.protocol.isSecure() && !destination.protocol.isSecure())
-                    throw DavException("Received redirect from HTTPS to HTTP")
-
-                // save new location and follow it
-                location = destination
-                followRedirects(prepareRequest, redirectCount + 1, block)
-            } else
-            // no redirect: pass scoped response to block, whose result becomes ours
-                block(response)
+                    RedirectOutcome.Redirected(destination)
+                } else
+                // no redirect: pass scoped response to block, whose result becomes ours
+                    RedirectOutcome.Done(block(response))
+            }
+            when (outcome) {
+                is RedirectOutcome.Redirected -> {
+                    // save new location and follow it in the next loop iteration, after this
+                    // hop's response/connection has already been released by execute()
+                    location = outcome.destination
+                    redirectCount++
+                }
+                is RedirectOutcome.Done -> return outcome.value
+            }
         }
+    }
 
 
     // Multi-Status handling

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -615,10 +615,10 @@ open class DavResource(
      *
      * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
      * @param block             called with the scoped response for the final resource that is not
-     *                          redirected anymore (may never be called if there are too many redirects);
-     *                          its return value becomes the return value of [followRedirects]
+     *                          redirected anymore (may never be called if there are too many redirects)
      *
      * @throws DavException     on invalid redirects or when the number of redirects has reached [MAX_REDIRECTS]
+     * @return value of [block]
      */
     internal suspend fun <T> followRedirects(
         prepareRequest: suspend () -> HttpStatement,
@@ -627,6 +627,8 @@ open class DavResource(
         var redirectCount = 0
         while (true) {
             val outcome = prepareRequest().execute { response ->
+                /* response body is available for streaming within this block. RedirectOutcome approach
+                * allows to process block(response), but close the body in case of a redirect. */
                 val isRedirect = response.status in arrayOf(
                     HttpStatusCode.MovedPermanently,
                     HttpStatusCode.Found,
@@ -634,9 +636,6 @@ open class DavResource(
                     HttpStatusCode.PermanentRedirect
                 )
                 if (isRedirect) {
-                    if (redirectCount + 1 >= MAX_REDIRECTS)
-                        throw DavException("Too many redirects")
-
                     // take new location from response header
                     val newLocation = response.headers[HttpHeaders.Location]
                         ?: throw DavException("Redirected without new Location")
@@ -650,18 +649,22 @@ open class DavResource(
                         throw DavException("Received redirect from HTTPS to HTTP")
 
                     RedirectOutcome.Redirected(destination)
-                } else
-                // no redirect: pass scoped response to block, whose result becomes ours
+                } else {
+                    // no redirect: run block and return its value
                     RedirectOutcome.Done(block(response))
+                }
             }
             when (outcome) {
                 is RedirectOutcome.Redirected -> {
-                    // save new location and follow it in the next loop iteration, after this
-                    // hop's response/connection has already been released by execute()
+                    // prevent redirect loop
+                    if (++redirectCount >= MAX_REDIRECTS)
+                        throw DavException("Too many redirects")
+
+                    // save new location and follow it in the next loop iteration
                     location = outcome.destination
-                    redirectCount++
                 }
-                is RedirectOutcome.Done -> return outcome.value
+                is RedirectOutcome.Done ->
+                    return outcome.value
             }
         }
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -603,7 +603,7 @@ open class DavResource(
     /**
      * Sends a request and follows up to [MAX_REDIRECTS] redirects.
      *
-     * @param prepareRequest    prepares the request (may be called multiple times with updated [location])
+     * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
      * @param block             called with the scoped response for the final resource that is not
      *                          redirected anymore (may never be called if there are too many redirects);
      *                          its return value becomes the return value of [followRedirects]
@@ -637,7 +637,8 @@ open class DavResource(
                     ?: throw DavException("Redirected without new Location")
 
                 // resolve possible relative location URL
-                val destination = location.resolve(newLocation) ?: throw DavException("Redirected to invalid Location")
+                val destination = location.resolve(newLocation)
+                    ?: throw DavException("Redirected to invalid Location")
 
                 // block insecure redirects
                 if (location.protocol.isSecure() && !destination.protocol.isSecure())

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -169,12 +169,9 @@ open class DavResource(
      */
     suspend fun options(followRedirects: Boolean = false, callback: CapabilitiesCallback) {
         if (followRedirects)
-            followRedirects(
-                prepareRequest = ::prepareOptionsRequest,
-                callback = { response ->
-                    processOptionsResponse(response, callback)
-                }
-            )
+            followRedirects(prepareRequest = ::prepareOptionsRequest) { response ->
+                processOptionsResponse(response, callback)
+            }
         else {
             prepareOptionsRequest().execute { response ->
                 processOptionsResponse(response, callback)
@@ -213,7 +210,7 @@ open class DavResource(
      * @throws DavException on WebDAV error or HTTPS -> HTTP redirect
      */
     suspend fun move(destination: Url, overwrite: Boolean, callback: ResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("MOVE")
 
@@ -243,7 +240,7 @@ open class DavResource(
      * @throws DavException on WebDAV error or HTTPS -> HTTP redirect
      */
     suspend fun copy(destination: Url, overwrite: Boolean, callback: ResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("COPY")
 
@@ -279,7 +276,7 @@ open class DavResource(
         additionalHeaders: Headers? = null,
         callback: ResponseCallback
     ) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location.withTrailingSlash()) {
                 method = HttpMethod.parse(methodName)
 
@@ -310,7 +307,7 @@ open class DavResource(
      * @throws DavException on HTTPS -> HTTP redirect
      */
     suspend fun head(callback: ResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareHead(location)
         }) { response ->
             checkStatus(response)
@@ -338,7 +335,7 @@ open class DavResource(
         disableCompression: Boolean = true,
         callback: ResponseCallback
     ) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareGet(location) {
                 if (additionalHeaders != null)
                     headers.appendAll(additionalHeaders)
@@ -370,7 +367,7 @@ open class DavResource(
      * @throws DavException on high-level errors
      */
     suspend fun getRange(offset: Long, size: Int, additionalHeaders: Headers? = null, callback: ResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareGet(location) {
                 val lastIndex = offset + size - 1
                 header(HttpHeaders.Range, "bytes=$offset-$lastIndex")
@@ -399,7 +396,7 @@ open class DavResource(
         additionalHeaders: Headers? = null,
         callback: ResponseCallback
     ) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.preparePost(location) {
                 if (additionalHeaders != null)
                     headers.appendAll(additionalHeaders)
@@ -431,7 +428,7 @@ open class DavResource(
         additionalHeaders: Headers? = null,
         callback: ResponseCallback
     ) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.preparePut(location) {
                 if (additionalHeaders != null)
                     headers.appendAll(additionalHeaders)
@@ -458,7 +455,7 @@ open class DavResource(
      * @throws DavException     on HTTPS -> HTTP redirect
      */
     suspend fun delete(additionalHeaders: Headers? = null, callback: ResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareDelete(location) {
                 if (additionalHeaders != null)
                     headers.appendAll(additionalHeaders)
@@ -500,7 +497,7 @@ open class DavResource(
         }
         serializer.endDocument()
 
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("PROPFIND")
 
@@ -538,7 +535,7 @@ open class DavResource(
     ) {
         val rqBody = createProppatchXml(setProperties, removeProperties)
 
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("PROPPATCH")
 
@@ -569,7 +566,7 @@ open class DavResource(
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
     suspend fun search(search: String, callback: MultiResponseCallback) {
-        followRedirects({
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("SEARCH")
 
@@ -604,53 +601,55 @@ open class DavResource(
     }
 
     /**
-     * Send a request and follows up to [MAX_REDIRECTS] redirects.
+     * Sends a request and follows up to [MAX_REDIRECTS] redirects.
      *
      * @param prepareRequest    prepares the request (may be called multiple times with updated [location])
-     * @param callback          called for the final resource that is not redirected anymore
-     *                          (may never be called if there are too many redirects)
+     * @param block             called with the scoped response for the final resource that is not
+     *                          redirected anymore (may never be called if there are too many redirects);
+     *                          its return value becomes the return value of [followRedirects]
      *
      * @throws DavException     on invalid redirects or when the number of redirects has reached [MAX_REDIRECTS]
      */
-    internal suspend fun followRedirects(prepareRequest: suspend () -> HttpStatement, callback: ResponseCallback) {
-        var redirects = 0
-        var finished = false
-        while (!finished) {
-            prepareRequest().execute { response ->
-                val isRedirect = response.status in arrayOf(
-                    HttpStatusCode.MovedPermanently,
-                    HttpStatusCode.Found,
-                    HttpStatusCode.TemporaryRedirect,
-                    HttpStatusCode.PermanentRedirect
-                )
-                if (isRedirect) {
-                    if (++redirects >= MAX_REDIRECTS)
-                        throw DavException("Too many redirects")
+    internal suspend fun <T> followRedirects(
+        prepareRequest: suspend () -> HttpStatement,
+        block: suspend (HttpResponse) -> T
+    ): T =
+        followRedirects(prepareRequest, redirectCount = 0, block)
 
-                    // take new location from response header
-                    val newLocation = response.headers[HttpHeaders.Location]
-                        ?: throw DavException("Redirected without new Location")
+    private suspend fun <T> followRedirects(
+        prepareRequest: suspend () -> HttpStatement,
+        redirectCount: Int,
+        block: suspend (HttpResponse) -> T
+    ): T =
+        prepareRequest().execute { response ->
+            val isRedirect = response.status in arrayOf(
+                HttpStatusCode.MovedPermanently,
+                HttpStatusCode.Found,
+                HttpStatusCode.TemporaryRedirect,
+                HttpStatusCode.PermanentRedirect
+            )
+            if (isRedirect) {
+                if (redirectCount + 1 >= MAX_REDIRECTS)
+                    throw DavException("Too many redirects")
 
-                    // resolve possible relative location URL
-                    val destination = location.resolve(newLocation) ?: throw DavException("Redirected to invalid Location")
+                // take new location from response header
+                val newLocation = response.headers[HttpHeaders.Location]
+                    ?: throw DavException("Redirected without new Location")
 
-                    // block insecure redirects
-                    if (location.protocol.isSecure() && !destination.protocol.isSecure())
-                        throw DavException("Received redirect from HTTPS to HTTP")
+                // resolve possible relative location URL
+                val destination = location.resolve(newLocation) ?: throw DavException("Redirected to invalid Location")
 
-                    // save new location
-                    location = destination
+                // block insecure redirects
+                if (location.protocol.isSecure() && !destination.protocol.isSecure())
+                    throw DavException("Received redirect from HTTPS to HTTP")
 
-                } else {
-                    // no redirect, pass scoped response to callback
-                    callback.onResponse(response)
-
-                    // quit loop (we can't use break because we're in the scoped execute() callback)
-                    finished = true
-                }
-            }
+                // save new location and follow it
+                location = destination
+                followRedirects(prepareRequest, redirectCount + 1, block)
+            } else
+            // no redirect: pass scoped response to block, whose result becomes ours
+                block(response)
         }
-    }
 
 
     // Multi-Status handling

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -197,7 +197,7 @@ class DavResourceTest {
         }
         val client = HttpClient(engine) { followRedirects = false }
         val dav = DavResource(client, sampleUrl)
-        dav.followRedirects({ client.prepareGet("https://from.com/") }) { response ->
+        dav.followRedirects(prepareRequest = { client.prepareGet("https://from.com/") }) { response ->
             assertEquals(HttpStatusCode.NoContent, response.status)
             assertEquals(Url("https://to.com/"), dav.location)
         }
@@ -210,7 +210,7 @@ class DavResourceTest {
         }
         val client = HttpClient(engine) { followRedirects = false }
         val dav = DavResource(client, Url("https://from.com"))
-        dav.followRedirects({ client.prepareGet("https://from.com/") }) {}
+        dav.followRedirects(prepareRequest = { client.prepareGet("https://from.com/") }) {}
     }
 
     @Test


### PR DESCRIPTION
Simplify `followRedirect()` from the non-suspending callback to a `suspend` block callback that returns the type of the block, so that

~~~kotlin
var result: List<Property>? = null
followRedirects(/*...*/) { response ->
    result = process(response)
}
return result ?: emptyList()

// becomes

val result = followRedirects(/*...*/) { response ->
    process(response)
}
~~~

Backwards-compatible: can still be used the old way – just ignore the return value.

---

Part of #200, preparation for #201