### PR TITLE
Replace `MultiResponseCallback` with `Flow<MultiStatusItem>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ are located in the `at.bitfire.dav4jvm.ktor` package.
 
 ## Roadmap
 
-**4.0:** API change: [Replace callback pattern by suspending functions / `Flow`
-s.)(https://github.com/bitfireAT/dav4jvm/issues/200)
+**4.0:** API change: [Replace callback pattern by suspending functions /
+`Flow`s](https://github.com/bitfireAT/dav4jvm/issues/200)
 
 Besides from that, no big changes are currently planned. There's the idea of making XML processing
 multiplatform-capable too at some time, but no specific plans. Maybe it will be renamed then
@@ -73,7 +73,9 @@ val httpClient = HttpClient(CIO) {
 }
 ```
 
-All dav4jvm request methods are `suspend` functions, so call them from a coroutine.
+Most dav4jvm request methods are `suspend` functions, so call them from a coroutine. Methods that
+process a WebDAV Multi-Status response (like `propfind`) return a `Flow` instead; the request is
+only sent (and errors only thrown) once that `Flow` is collected.
 
 
 ### Files
@@ -100,9 +102,11 @@ To list a folder's contents, you need to pass in which properties to fetch:
 val location = Url("https://example.com/webdav/")
 val davCollection = DavCollection(httpClient, location)
 
-davCollection.propfind(depth = 1, DisplayName.NAME, GetLastModified.NAME) { response, relation ->
-    // This callback will be called for every file in the folder.
-    // Use `response.properties` to access the successfully retrieved properties.
+davCollection.propfind(depth = 1, DisplayName.NAME, GetLastModified.NAME).collect { item ->
+    if (item is MultiStatusItem.Response) {
+        // This is called for every file in the folder.
+        // Use `item.response.properties` to access the successfully retrieved properties.
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ are located in the `at.bitfire.dav4jvm.ktor` package.
 
 ## Roadmap
 
-Currently no big changes are planned. There's the idea of making XML processing
+**4.0:** API change: [Replace callback pattern by suspending functions / `Flow`
+s.)(https://github.com/bitfireAT/dav4jvm/issues/200)
+
+Besides from that, no big changes are currently planned. There's the idea of making XML processing
 multiplatform-capable too at some time, but no specific plans. Maybe it will be renamed then
 to dav4kmp or something like that.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,7 @@ tasks.withType<DokkaTask>().configureEach {
 }
 
 dependencies {
+    api(libs.kotlin.coroutines.core)
     api(libs.ktor.client.core)
     api(libs.spotbugs.annotations)
     api(libs.xpp3)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ktor = "3.5.1"
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
+kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlin-coroutines" }
 kotlin-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/CallbackInterfaces.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/CallbackInterfaces.kt
@@ -20,23 +20,6 @@ fun interface CapabilitiesCallback {
 }
 
 /**
- * Callback for 207 Multi-Status responses.
- */
-fun interface MultiResponseCallback {
-    /**
-     * Called for every `<response>` element in the `<multistatus>` body. For instance,
-     * in response to a `PROPFIND` request, this callback will be called once for every found
-     * member resource.
-     *
-     * Known collections have [response] `href` with trailing slash, see [Response.parse] for details.
-     *
-     * @param response   the parsed response (including URL)
-     * @param relation   relation of the response to the called resource
-     */
-    suspend fun onResponse(response: Response, relation: Response.HrefRelation)
-}
-
-/**
  * Callback for HTTP responses.
  */
 fun interface ResponseCallback {

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -39,8 +39,7 @@ class DavAddressBook(
      *
      * Collect the returned flow while the underlying `HttpClient` is still open.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
-     * properties which are not part of a `<response>` element
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -90,8 +89,7 @@ class DavAddressBook(
      *
      * Collect the returned flow while the underlying `HttpClient` is still open.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
-     * properties which are not part of a `<response>` element
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -37,6 +37,8 @@ class DavAddressBook(
     /**
      * Sends an addressbook-query REPORT request to the resource.
      *
+     * Collect the returned flow while the underlying `HttpClient` is still open.
+     *
      * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
      * properties which are not part of a `<response>` element
      *
@@ -85,6 +87,8 @@ class DavAddressBook(
      *                     "application/vcard+json" for jCard. *null*: don't request specific representation type
      * @param version      vCard version subtype of the requested format. Should only be specified together with a [contentType] of "text/vcard".
      *                     Currently only useful value: "4.0" for vCard 4. *null*: don't request specific version
+     *
+     * Collect the returned flow while the underlying `HttpClient` is still open.
      *
      * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
      * properties which are not part of a `<response>` element

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -25,7 +25,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.util.logging.Logger
 
@@ -45,7 +44,7 @@ class DavAddressBook(
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    fun addressbookQuery(): Flow<MultiStatusItem> = flow {
+    fun addressbookQuery(): Flow<MultiStatusItem> {
         /* <!ELEMENT addressbook-query ((DAV:allprop |
                                          DAV:propname |
                                          DAV:prop)?, filter, limit?)>
@@ -65,7 +64,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -75,8 +74,6 @@ class DavAddressBook(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 
@@ -100,7 +97,7 @@ class DavAddressBook(
         urls: List<Url>,
         contentType: String? = null,
         version: String? = null
-    ): Flow<MultiStatusItem> = flow {
+    ): Flow<MultiStatusItem> {
         /* <!ELEMENT addressbook-multiget ((DAV:allprop |
                                             DAV:propname |
                                             DAV:prop)?,
@@ -130,7 +127,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -140,8 +137,6 @@ class DavAddressBook(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -37,9 +37,7 @@ class DavAddressBook(
     /**
      * Sends an addressbook-query REPORT request to the resource.
      *
-     * Collect the returned flow while the underlying `HttpClient` is still open.
-     *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -87,9 +85,7 @@ class DavAddressBook(
      * @param version      vCard version subtype of the requested format. Should only be specified together with a [contentType] of "text/vcard".
      *                     Currently only useful value: "4.0" for vCard 4. *null*: don't request specific version
      *
-     * Collect the returned flow while the underlying `HttpClient` is still open.
-     *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -37,7 +37,7 @@ class DavAddressBook(
     /**
      * Sends an addressbook-query REPORT request to the resource.
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -85,7 +85,7 @@ class DavAddressBook(
      * @param version      vCard version subtype of the requested format. Should only be specified together with a [contentType] of "text/vcard".
      *                     Currently only useful value: "4.0" for vCard 4. *null*: don't request specific version
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -10,7 +10,6 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.XmlUtils
 import at.bitfire.dav4jvm.XmlUtils.insertTag
 import at.bitfire.dav4jvm.property.carddav.AddressData
@@ -25,6 +24,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.util.logging.Logger
 
@@ -37,16 +38,14 @@ class DavAddressBook(
     /**
      * Sends an addressbook-query REPORT request to the resource.
      *
-     * @param callback called for every WebDAV response XML element in the result
-     *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
+     * properties which are not part of a `<response>` element
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    suspend fun addressbookQuery(callback: MultiResponseCallback): List<Property> {
+    fun addressbookQuery(): Flow<MultiStatusItem> = flow {
         /* <!ELEMENT addressbook-query ((DAV:allprop |
                                          DAV:propname |
                                          DAV:prop)?, filter, limit?)>
@@ -66,7 +65,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        return followRedirects(prepareRequest = {
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -77,7 +76,7 @@ class DavAddressBook(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 
@@ -89,21 +88,19 @@ class DavAddressBook(
      *                     "application/vcard+json" for jCard. *null*: don't request specific representation type
      * @param version      vCard version subtype of the requested format. Should only be specified together with a [contentType] of "text/vcard".
      *                     Currently only useful value: "4.0" for vCard 4. *null*: don't request specific version
-     * @param callback     called for every WebDAV response XML element in the result
      *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
+     * properties which are not part of a `<response>` element
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    suspend fun multiget(
+    fun multiget(
         urls: List<Url>,
         contentType: String? = null,
-        version: String? = null,
-        callback: MultiResponseCallback
-    ): List<Property> {
+        version: String? = null
+    ): Flow<MultiStatusItem> = flow {
         /* <!ELEMENT addressbook-multiget ((DAV:allprop |
                                             DAV:propname |
                                             DAV:prop)?,
@@ -133,7 +130,7 @@ class DavAddressBook(
         }
         serializer.endDocument()
 
-        return followRedirects(prepareRequest = {
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -144,7 +141,7 @@ class DavAddressBook(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBook.kt
@@ -32,12 +32,12 @@ class DavAddressBook(
     httpClient: HttpClient,
     location: Url,
     logger: Logger = Logger.getLogger(javaClass.name)
-): DavCollection(httpClient, location, logger) {
+) : DavCollection(httpClient, location, logger) {
 
     /**
      * Sends an addressbook-query REPORT request to the resource.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -85,7 +85,7 @@ class DavAddressBook(
      * @param version      vCard version subtype of the requested format. Should only be specified together with a [contentType] of "text/vcard".
      *                     Currently only useful value: "4.0" for vCard 4. *null*: don't request specific version
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -49,6 +49,8 @@ class DavCalendar(
      * @param end       time-range filter: end date (optional)
      * @param props     requested WebDAV properties for results (default: only [WebDAV.GetETag]; use [CalDAV.CalendarData] to receive full iCalendars)
      *
+     * Collect the returned flow while the underlying `HttpClient` is still open.
+     *
      * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
      * properties which are not part of a `<response>` element
      *
@@ -128,6 +130,8 @@ class DavCalendar(
      * @param contentType  MIME type of requested format; may be "text/calendar" for iCalendar or
      *                     "application/calendar+json" for jCard. *null*: don't request specific representation type
      * @param version      Version subtype of the requested format, like "2.0" for iCalendar 2. *null*: don't request specific version
+     *
+     * Collect the returned flow while the underlying `HttpClient` is still open.
      *
      * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
      * properties which are not part of a `<response>` element

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -49,9 +49,7 @@ class DavCalendar(
      * @param end       time-range filter: end date (optional)
      * @param props     requested WebDAV properties for results (default: only [WebDAV.GetETag]; use [CalDAV.CalendarData] to receive full iCalendars)
      *
-     * Collect the returned flow while the underlying `HttpClient` is still open.
-     *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -130,9 +128,7 @@ class DavCalendar(
      *                     "application/calendar+json" for jCard. *null*: don't request specific representation type
      * @param version      Version subtype of the requested format, like "2.0" for iCalendar 2. *null*: don't request specific version
      *
-     * Collect the returned flow while the underlying `HttpClient` is still open.
-     *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -49,7 +49,7 @@ class DavCalendar(
      * @param end       time-range filter: end date (optional)
      * @param props     requested WebDAV properties for results (default: only [WebDAV.GetETag]; use [CalDAV.CalendarData] to receive full iCalendars)
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -128,7 +128,7 @@ class DavCalendar(
      *                     "application/calendar+json" for jCard. *null*: don't request specific representation type
      * @param version      Version subtype of the requested format, like "2.0" for iCalendar 2. *null*: don't request specific version
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -49,7 +49,7 @@ class DavCalendar(
      * @param end       time-range filter: end date (optional)
      * @param props     requested WebDAV properties for results (default: only [WebDAV.GetETag]; use [CalDAV.CalendarData] to receive full iCalendars)
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -128,7 +128,7 @@ class DavCalendar(
      *                     "application/calendar+json" for jCard. *null*: don't request specific representation type
      * @param version      Version subtype of the requested format, like "2.0" for iCalendar 2. *null*: don't request specific version
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -51,8 +51,7 @@ class DavCalendar(
      *
      * Collect the returned flow while the underlying `HttpClient` is still open.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
-     * properties which are not part of a `<response>` element
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
@@ -133,8 +132,7 @@ class DavCalendar(
      *
      * Collect the returned flow while the underlying `HttpClient` is still open.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
-     * properties which are not part of a `<response>` element
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -25,6 +25,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.time.Instant
 import java.time.ZoneOffset
@@ -47,22 +49,20 @@ class DavCalendar(
      * @param start     time-range filter: start date (optional)
      * @param end       time-range filter: end date (optional)
      * @param props     requested WebDAV properties for results (default: only [WebDAV.GetETag]; use [CalDAV.CalendarData] to receive full iCalendars)
-     * @param callback  called for every WebDAV response XML element in the result
      *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
+     * properties which are not part of a `<response>` element
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    suspend fun calendarQuery(
+    fun calendarQuery(
         component: String,
         start: Instant?,
         end: Instant?,
-        props: Set<Property.Name> = setOf(WebDAV.GetETag),
-        callback: MultiResponseCallback
-    ): List<Property> {
+        props: Set<Property.Name> = setOf(WebDAV.GetETag)
+    ): Flow<MultiStatusItem> = flow {
         /* <!ELEMENT calendar-query ((DAV:allprop |
                                       DAV:propname |
                                       DAV:prop)?, filter, timezone?)>
@@ -108,7 +108,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        return followRedirects(prepareRequest = {
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -119,33 +119,31 @@ class DavCalendar(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 
     /**
-     * Sends a calendar-multiget REPORT to the resource. Received responses are sent
-     * to the callback, whether they are successful (2xx) or not.
+     * Sends a calendar-multiget REPORT to the resource. Received responses are emitted
+     * whether they are successful (2xx) or not.
      *
      * @param urls         list of iCalendar URLs to be requested
      * @param contentType  MIME type of requested format; may be "text/calendar" for iCalendar or
      *                     "application/calendar+json" for jCard. *null*: don't request specific representation type
      * @param version      Version subtype of the requested format, like "2.0" for iCalendar 2. *null*: don't request specific version
-     * @param callback     called for every WebDAV response XML element in the result
      *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
+     * properties which are not part of a `<response>` element
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    suspend fun multiget(
+    fun multiget(
         urls: List<Url>,
         contentType: String? = null,
-        version: String? = null,
-        callback: MultiResponseCallback
-    ): List<Property> {
+        version: String? = null
+    ): Flow<MultiStatusItem> = flow {
         /* <!ELEMENT calendar-multiget ((DAV:allprop |
                                         DAV:propname |
                                         DAV:prop)?, DAV:href+)>
@@ -175,7 +173,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        return followRedirects(prepareRequest = {
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -184,7 +182,7 @@ class DavCalendar(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCalendar.kt
@@ -26,7 +26,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.time.Instant
 import java.time.ZoneOffset
@@ -62,7 +61,7 @@ class DavCalendar(
         start: Instant?,
         end: Instant?,
         props: Set<Property.Name> = setOf(WebDAV.GetETag)
-    ): Flow<MultiStatusItem> = flow {
+    ): Flow<MultiStatusItem> {
         /* <!ELEMENT calendar-query ((DAV:allprop |
                                       DAV:propname |
                                       DAV:prop)?, filter, timezone?)>
@@ -108,7 +107,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -118,8 +117,6 @@ class DavCalendar(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 
@@ -143,7 +140,7 @@ class DavCalendar(
         urls: List<Url>,
         contentType: String? = null,
         version: String? = null
-    ): Flow<MultiStatusItem> = flow {
+    ): Flow<MultiStatusItem> {
         /* <!ELEMENT calendar-multiget ((DAV:allprop |
                                         DAV:propname |
                                         DAV:prop)?, DAV:href+)>
@@ -173,7 +170,7 @@ class DavCalendar(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -181,8 +178,6 @@ class DavCalendar(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -23,7 +23,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.util.logging.Logger
 
@@ -57,7 +56,7 @@ open class DavCollection @JvmOverloads constructor(
         infiniteDepth: Boolean,
         limit: Int?,
         vararg properties: Property.Name
-    ): Flow<MultiStatusItem> = flow {
+    ): Flow<MultiStatusItem> {
         /* <!ELEMENT sync-collection (sync-token, sync-level, limit?, prop)>
 
            <!ELEMENT sync-token CDATA>       <!-- Text MUST be a URI -->
@@ -94,7 +93,7 @@ open class DavCollection @JvmOverloads constructor(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -104,8 +103,6 @@ open class DavCollection @JvmOverloads constructor(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -38,13 +38,15 @@ open class DavCollection @JvmOverloads constructor(
     /**
      * Sends a REPORT sync-collection request.
      *
+     * The returned flow includes `sync-token`, emitted as [MultiStatusItem.ExtraProperty] holding a
+     * [at.bitfire.dav4jvm.property.webdav.SyncToken] — stopping collection early may miss it.
+     *
      * @param syncToken     sync-token to be sent with the request
      * @param infiniteDepth sync-level to be sent with the request: false = "1", true = "infinite"
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable;
-     * includes `sync-token`, emitted as [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -43,7 +43,7 @@ open class DavCollection @JvmOverloads constructor(
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable;
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable;
      * includes `sync-token`, emitted as [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
      *
      * @throws java.io.IOException on I/O error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -46,7 +46,7 @@ open class DavCollection @JvmOverloads constructor(
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -22,6 +22,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.Url
 import io.ktor.http.contentType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.io.StringWriter
 import java.util.logging.Logger
 
@@ -41,22 +43,21 @@ open class DavCollection @JvmOverloads constructor(
      * @param infiniteDepth sync-level to be sent with the request: false = "1", true = "infinite"
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
-     * @param callback      called for every WebDAV response XML element in the result
      *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements (like `sync-token` which is returned as [at.bitfire.dav4jvm.property.webdav.SyncToken])
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
+     * properties which are not part of a `<response>` element (like `sync-token`, emitted as
+     * [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error
      * @throws at.bitfire.dav4jvm.ktor.exception.DavException on WebDAV error
      */
-    suspend fun reportChanges(
+    fun reportChanges(
         syncToken: String?,
         infiniteDepth: Boolean,
         limit: Int?,
-        vararg properties: Property.Name,
-        callback: MultiResponseCallback
-    ): List<Property> {
+        vararg properties: Property.Name
+    ): Flow<MultiStatusItem> = flow {
         /* <!ELEMENT sync-collection (sync-token, sync-level, limit?, prop)>
 
            <!ELEMENT sync-token CDATA>       <!-- Text MUST be a URI -->
@@ -93,7 +94,7 @@ open class DavCollection @JvmOverloads constructor(
         }
         serializer.endDocument()
 
-        return followRedirects(prepareRequest = {
+        followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("REPORT")
 
@@ -104,7 +105,7 @@ open class DavCollection @JvmOverloads constructor(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -43,6 +43,8 @@ open class DavCollection @JvmOverloads constructor(
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
      *
+     * Collect the returned flow while the underlying `HttpClient` is still open.
+     *
      * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
      * properties which are not part of a `<response>` element (like `sync-token`, emitted as
      * [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -45,8 +45,7 @@ open class DavCollection @JvmOverloads constructor(
      *
      * Collect the returned flow while the underlying `HttpClient` is still open.
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response, including extra
-     * properties which are not part of a `<response>` element (like `sync-token`, emitted as
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (like `sync-token`, emitted as
      * [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
      *
      * @throws java.io.IOException on I/O error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavCollection.kt
@@ -43,10 +43,8 @@ open class DavCollection @JvmOverloads constructor(
      * @param limit         maximum number of results (may cause truncation)
      * @param properties    WebDAV properties to be requested
      *
-     * Collect the returned flow while the underlying `HttpClient` is still open.
-     *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (like `sync-token`, emitted as
-     * [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable;
+     * includes `sync-token`, emitted as [MultiStatusItem.ExtraProperty] holding a [at.bitfire.dav4jvm.property.webdav.SyncToken])
      *
      * @throws java.io.IOException on I/O error
      * @throws at.bitfire.dav4jvm.ktor.exception.HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -51,7 +51,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import io.ktor.utils.io.peek
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.io.bytestring.encodeToByteString
 import org.xmlpull.v1.XmlPullParser
@@ -486,7 +486,7 @@ open class DavResource(
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
-    fun propfind(depth: Int, vararg reqProp: Property.Name): Flow<MultiStatusItem> = flow {
+    fun propfind(depth: Int, vararg reqProp: Property.Name): Flow<MultiStatusItem> {
         // build XML request body
         val serializer = XmlUtils.newSerializer()
         val writer = StringWriter()
@@ -503,7 +503,7 @@ open class DavResource(
         }
         serializer.endDocument()
 
-        followRedirects(prepareRequest = {
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("PROPFIND")
 
@@ -513,8 +513,6 @@ open class DavResource(
                 contentType(MIME_XML_UTF8)
                 setBody(writer.toString())
             }
-        }) { response ->
-            processMultiStatus(response, this@flow)
         }
     }
 
@@ -540,10 +538,13 @@ open class DavResource(
     fun proppatch(
         setProperties: Map<Property.Name, String>,
         removeProperties: List<Property.Name>
-    ): Flow<MultiStatusItem> = flow {
+    ): Flow<MultiStatusItem> {
         val rqBody = createProppatchXml(setProperties, removeProperties)
 
-        followRedirects(prepareRequest = {
+        // room for further improvement: handle not only 207 Multi-Status
+        // http://www.webdav.org/specs/rfc4918.html#PROPPATCH-status
+
+        return multiStatusFlow {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("PROPPATCH")
 
@@ -551,11 +552,6 @@ open class DavResource(
                 contentType(MIME_XML_UTF8)
                 setBody(rqBody)
             }
-        }) { response ->
-            // room for further improvement: handle not only 207 Multi-Status
-            // http://www.webdav.org/specs/rfc4918.html#PROPPATCH-status
-
-            processMultiStatus(response, this@flow)
         }
     }
 
@@ -576,17 +572,13 @@ open class DavResource(
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
-    fun search(search: String): Flow<MultiStatusItem> = flow {
-        followRedirects(prepareRequest = {
-            httpClient.prepareRequest(location) {
-                method = HttpMethod.parse("SEARCH")
+    fun search(search: String): Flow<MultiStatusItem> = multiStatusFlow {
+        httpClient.prepareRequest(location) {
+            method = HttpMethod.parse("SEARCH")
 
-                acceptXml()
-                contentType(MIME_XML_UTF8)
-                setBody(search)
-            }
-        }) { response ->
-            processMultiStatus(response, this@flow)
+            acceptXml()
+            contentType(MIME_XML_UTF8)
+            setBody(search)
         }
     }
 
@@ -732,16 +724,21 @@ open class DavResource(
     /**
      * Processes a Multi-Status response.
      *
+     * The [response] must still be open (its body not yet closed) when the returned [Flow] is
+     * collected — collect it (for instance with [kotlinx.coroutines.flow.emitAll]) before returning
+     * from the block that received [response].
+     *
      * @param response  unconsumed response which is expected to contain a Multi-Status response
-     * @param collector collector that every [MultiStatusItem] found in the Multi-Status response
-     *                  is emitted into (both `<response>` elements and extra properties like
-     *                  `sync-token`, which is emitted as [MultiStatusItem.ExtraProperty] holding a [SyncToken])
+     *
+     * @return flow of every [MultiStatusItem] found in the Multi-Status response (both `<response>`
+     * elements and extra properties like `sync-token`, emitted as [MultiStatusItem.ExtraProperty]
+     * holding a [SyncToken])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (for instance, when the response is not a Multi-Status response)
      */
-    protected suspend fun processMultiStatus(response: HttpResponse, collector: FlowCollector<MultiStatusItem>) {
+    protected fun processMultiStatus(response: HttpResponse): Flow<MultiStatusItem> = flow {
         checkStatus(response)
         val bodyChannel = response.bodyAsChannel()
 
@@ -758,8 +755,8 @@ open class DavResource(
                 while (eventType != XmlPullParser.END_DOCUMENT) {
                     if (eventType == XmlPullParser.START_TAG && parser.depth == 1)
                         if (parser.propertyName() == WebDAV.MultiStatus) {
-                            MultiStatusParser(location).parseResponse(parser, collector)
-                            return
+                            MultiStatusParser(location).parseResponse(parser, this)
+                            return@flow
                             // further <multistatus> elements are ignored
                         }
 
@@ -773,6 +770,21 @@ open class DavResource(
             throw DavException("Incomplete multistatus XML element", cause = e)
         } catch (e: XmlPullParserException) {
             throw DavException("Couldn't parse multistatus XML element", cause = e)
+        }
+    }
+
+    /**
+     * Sends a request and processes its Multi-Status response, following up to [MAX_REDIRECTS] redirects.
+     * Combines [followRedirects] and [processMultiStatus] into a single [Flow] — the request is only
+     * sent (and the flow only throws) once it's collected.
+     *
+     * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
+     *
+     * @return flow of every [MultiStatusItem] found in the Multi-Status response
+     */
+    protected fun multiStatusFlow(prepareRequest: suspend () -> HttpStatement): Flow<MultiStatusItem> = flow {
+        followRedirects(prepareRequest) { response ->
+            emitAll(processMultiStatus(response))
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -669,6 +669,52 @@ open class DavResource(
     // Multi-Status handling
 
     /**
+     * Validates a 207 Multi-Status response.
+     *
+     * @param httpResponse  response that will be checked for Multi-Status
+     * @param bodyChannel   response body channel that will be peeked into in order to
+     *                      determine whether it's XML
+     *
+     * @throws DavException if the response is not a Multi-Status response with XML body
+     */
+    suspend fun assertMultiStatus(httpResponse: HttpResponse, bodyChannel: ByteReadChannel) {
+        if (httpResponse.status != HttpStatusCode.MultiStatus)
+            throw DavException.fromResponse(
+                message = "Expected 207 Multi-Status, got ${httpResponse.status}",
+                response = httpResponse,
+                responseBodyChannel = bodyChannel
+            )
+
+        val contentType = httpResponse.contentType()
+        if (contentType == null) {
+            logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
+            return  // supposed XML response body, fine
+        }
+
+        if (contentType.isXml())
+            return  // reported XML response body, fine
+
+        /* Content-Type is not application/xml or text/xml although that is expected here.
+           Some broken servers return an XML response with some other MIME type. So we try to see
+           whether the response is maybe XML although the Content-Type is something else. */
+        try {
+            val firstBytes = bodyChannel.peek(XML_SIGNATURE.size)
+            if (firstBytes == XML_SIGNATURE) {
+                logger.warning("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
+                return  // response body starts with XML signature, fine
+            }
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
+        }
+
+        // non-XML response body
+        throw DavException.fromResponse(
+            message = "Received non-XML 207 Multi-Status",
+            response = httpResponse
+        )
+    }
+
+    /**
      * Processes a Multi-Status response.
      *
      * The [response] must still be open (its body not yet closed) when the returned [Flow] is
@@ -718,52 +764,6 @@ open class DavResource(
         } catch (e: XmlPullParserException) {
             throw DavException("Couldn't parse multistatus XML element", cause = e)
         }
-    }
-
-    /**
-     * Validates a 207 Multi-Status response.
-     *
-     * @param httpResponse  response that will be checked for Multi-Status
-     * @param bodyChannel   response body channel that will be peeked into in order to
-     *                      determine whether it's XML
-     *
-     * @throws DavException if the response is not a Multi-Status response with XML body
-     */
-    suspend fun assertMultiStatus(httpResponse: HttpResponse, bodyChannel: ByteReadChannel) {
-        if (httpResponse.status != HttpStatusCode.MultiStatus)
-            throw DavException.fromResponse(
-                message = "Expected 207 Multi-Status, got ${httpResponse.status}",
-                response = httpResponse,
-                responseBodyChannel = bodyChannel
-            )
-
-        val contentType = httpResponse.contentType()
-        if (contentType == null) {
-            logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
-            return  // supposed XML response body, fine
-        }
-
-        if (contentType.isXml())
-            return  // reported XML response body, fine
-
-        /* Content-Type is not application/xml or text/xml although that is expected here.
-           Some broken servers return an XML response with some other MIME type. So we try to see
-           whether the response is maybe XML although the Content-Type is something else. */
-        try {
-            val firstBytes = bodyChannel.peek(XML_SIGNATURE.size)
-            if (firstBytes == XML_SIGNATURE) {
-                logger.warning("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
-                return  // response body starts with XML signature, fine
-            }
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
-        }
-
-        // non-XML response body
-        throw DavException.fromResponse(
-            message = "Received non-XML 207 Multi-Status",
-            response = httpResponse
-        )
     }
 
     /**

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -50,6 +50,9 @@ import io.ktor.http.withCharset
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import io.ktor.utils.io.peek
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
 import kotlinx.io.bytestring.encodeToByteString
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
@@ -472,15 +475,18 @@ open class DavResource(
      *
      * Follows up to [MAX_REDIRECTS] redirects.
      *
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     *
      * @param depth    "Depth" header to send (-1 for `infinity`)
      * @param reqProp  properties to request
-     * @param callback called for every XML response element in the Multi-Status response
+     *
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
-    suspend fun propfind(depth: Int, vararg reqProp: Property.Name, callback: MultiResponseCallback) {
+    fun propfind(depth: Int, vararg reqProp: Property.Name): Flow<MultiStatusItem> = flow {
         // build XML request body
         val serializer = XmlUtils.newSerializer()
         val writer = StringWriter()
@@ -508,7 +514,7 @@ open class DavResource(
                 setBody(writer.toString())
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 
@@ -520,19 +526,21 @@ open class DavResource(
      * Currently expects a 207 Multi-Status response although servers are allowed to
      * return other values, too.
      *
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     *
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
      * @param removeProperties  list of names of properties that shall be removed
-     * @param callback          called for every XML response element in the Multi-Status response
+     *
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
-    suspend fun proppatch(
+    fun proppatch(
         setProperties: Map<Property.Name, String>,
-        removeProperties: List<Property.Name>,
-        callback: MultiResponseCallback
-    ) {
+        removeProperties: List<Property.Name>
+    ): Flow<MultiStatusItem> = flow {
         val rqBody = createProppatchXml(setProperties, removeProperties)
 
         followRedirects(prepareRequest = {
@@ -547,7 +555,7 @@ open class DavResource(
             // room for further improvement: handle not only 207 Multi-Status
             // http://www.webdav.org/specs/rfc4918.html#PROPPATCH-status
 
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 
@@ -558,14 +566,17 @@ open class DavResource(
      *
      * Expects a 207 Multi-Status response.
      *
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
-     * @param callback  called for every XML response element in the Multi-Status response
+     *
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (like no 207 Multi-Status response) or HTTPS -> HTTP redirect
      */
-    suspend fun search(search: String, callback: MultiResponseCallback) {
+    fun search(search: String): Flow<MultiStatusItem> = flow {
         followRedirects(prepareRequest = {
             httpClient.prepareRequest(location) {
                 method = HttpMethod.parse("SEARCH")
@@ -575,7 +586,7 @@ open class DavResource(
                 setBody(search)
             }
         }) { response ->
-            processMultiStatus(response, callback)
+            processMultiStatus(response, this@flow)
         }
     }
 
@@ -721,17 +732,16 @@ open class DavResource(
     /**
      * Processes a Multi-Status response.
      *
-     * @param response unconsumed response which is expected to contain a Multi-Status response
-     * @param callback called for every XML response element in the Multi-Status response
-     *
-     * @return list of properties which have been received in the Multi-Status response, but
-     * are not part of response XML elements (like `sync-token` which is returned as [SyncToken])
+     * @param response  unconsumed response which is expected to contain a Multi-Status response
+     * @param collector collector that every [MultiStatusItem] found in the Multi-Status response
+     *                  is emitted into (both `<response>` elements and extra properties like
+     *                  `sync-token`, which is emitted as [MultiStatusItem.ExtraProperty] holding a [SyncToken])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (for instance, when the response is not a Multi-Status response)
      */
-    protected suspend fun processMultiStatus(response: HttpResponse, callback: MultiResponseCallback): List<Property> {
+    protected suspend fun processMultiStatus(response: HttpResponse, collector: FlowCollector<MultiStatusItem>) {
         checkStatus(response)
         val bodyChannel = response.bodyAsChannel()
 
@@ -748,7 +758,8 @@ open class DavResource(
                 while (eventType != XmlPullParser.END_DOCUMENT) {
                     if (eventType == XmlPullParser.START_TAG && parser.depth == 1)
                         if (parser.propertyName() == WebDAV.MultiStatus) {
-                            return MultiStatusParser(location, callback).parseResponse(parser)
+                            MultiStatusParser(location).parseResponse(parser, collector)
+                            return
                             // further <multistatus> elements are ignored
                         }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -477,7 +477,7 @@ open class DavResource(
      * @param depth    "Depth" header to send (-1 for `infinity`)
      * @param reqProp  properties to request
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -524,7 +524,7 @@ open class DavResource(
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
      * @param removeProperties  list of names of properties that shall be removed
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -559,7 +559,7 @@ open class DavResource(
      *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -677,7 +677,7 @@ open class DavResource(
      *
      * @param response  unconsumed response which is expected to contain a Multi-Status response
      *
-     * @return flow of every [MultiStatusItem] found in the Multi-Status response (both `<response>`
+     * @return cold flow of every [MultiStatusItem] found in the Multi-Status response (both `<response>`
      * elements and extra properties like `sync-token`, emitted as [MultiStatusItem.ExtraProperty]
      * holding a [SyncToken])
      *

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -51,7 +51,7 @@ import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toInputStream
 import io.ktor.utils.io.peek
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.io.bytestring.encodeToByteString
 import org.xmlpull.v1.XmlPullParser
@@ -717,21 +717,19 @@ open class DavResource(
     /**
      * Processes a Multi-Status response.
      *
-     * The [response] must still be open (its body not yet closed) when the returned [Flow] is
-     * collected — collect it (for instance with [kotlinx.coroutines.flow.emitAll]) before returning
-     * from the block that received [response].
+     * The [response] must still be open (its body not yet closed) while [collector] is being fed —
+     * call this from within the block that received [response], before it returns.
      *
      * @param response  unconsumed response which is expected to contain a Multi-Status response
-     *
-     * @return cold flow of every [MultiStatusItem] found in the Multi-Status response (both `<response>`
-     * elements and extra properties like `sync-token`, emitted as [MultiStatusItem.ExtraProperty]
-     * holding a [SyncToken])
+     * @param collector collector that every [MultiStatusItem] found in the Multi-Status response is
+     *                  emitted into (both `<response>` elements and extra properties like `sync-token`,
+     *                  emitted as [MultiStatusItem.ExtraProperty] holding a [SyncToken])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (for instance, when the response is not a Multi-Status response)
      */
-    protected fun processMultiStatus(response: HttpResponse): Flow<MultiStatusItem> = flow {
+    protected suspend fun processMultiStatus(response: HttpResponse, collector: FlowCollector<MultiStatusItem>) {
         checkStatus(response)
         val bodyChannel = response.bodyAsChannel()
 
@@ -748,8 +746,8 @@ open class DavResource(
                 while (eventType != XmlPullParser.END_DOCUMENT) {
                     if (eventType == XmlPullParser.START_TAG && parser.depth == 1)
                         if (parser.propertyName() == WebDAV.MultiStatus) {
-                            MultiStatusParser(location).parseResponse(parser, this)
-                            return@flow
+                            MultiStatusParser(location).parseResponse(parser, collector)
+                            return
                             // further <multistatus> elements are ignored
                         }
 
@@ -777,7 +775,7 @@ open class DavResource(
      */
     protected fun multiStatusFlow(prepareRequest: suspend () -> HttpStatement): Flow<MultiStatusItem> = flow {
         followRedirects(prepareRequest) { response ->
-            emitAll(processMultiStatus(response))
+            processMultiStatus(response, this)
         }
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -474,13 +474,10 @@ open class DavResource(
      *
      * Follows up to [MAX_REDIRECTS] redirects.
      *
-     * The request is only sent once the [Flow] is collected —
-     * collect it while [httpClient] is still open.
-     *
      * @param depth    "Depth" header to send (-1 for `infinity`)
      * @param reqProp  properties to request
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -524,13 +521,10 @@ open class DavResource(
      * Currently expects a 207 Multi-Status response although servers are allowed to
      * return other values, too.
      *
-     * The request is only sent once the [Flow] is collected —
-     * collect it while [httpClient] is still open.
-     *
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
      * @param removeProperties  list of names of properties that shall be removed
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -563,12 +557,9 @@ open class DavResource(
      *
      * Expects a 207 Multi-Status response.
      *
-     * The request is only sent once the [Flow] is collected —
-     * collect it while [httpClient] is still open.
-     *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
      *
-     * @return flow of [MultiStatusItem]s found in the Multi-Status response
+     * @return flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -678,52 +669,6 @@ open class DavResource(
     // Multi-Status handling
 
     /**
-     * Validates a 207 Multi-Status response.
-     *
-     * @param httpResponse  response that will be checked for Multi-Status
-     * @param bodyChannel   response body channel that will be peeked into in order to
-     *                      determine whether it's XML
-     *
-     * @throws DavException if the response is not a Multi-Status response with XML body
-     */
-    suspend fun assertMultiStatus(httpResponse: HttpResponse, bodyChannel: ByteReadChannel) {
-        if (httpResponse.status != HttpStatusCode.MultiStatus)
-            throw DavException.fromResponse(
-                message = "Expected 207 Multi-Status, got ${httpResponse.status}",
-                response = httpResponse,
-                responseBodyChannel = bodyChannel
-            )
-
-        val contentType = httpResponse.contentType()
-        if (contentType == null) {
-            logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
-            return  // supposed XML response body, fine
-        }
-
-        if (contentType.isXml())
-            return  // reported XML response body, fine
-
-        /* Content-Type is not application/xml or text/xml although that is expected here.
-           Some broken servers return an XML response with some other MIME type. So we try to see
-           whether the response is maybe XML although the Content-Type is something else. */
-        try {
-            val firstBytes = bodyChannel.peek(XML_SIGNATURE.size)
-            if (firstBytes == XML_SIGNATURE) {
-                logger.warning("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
-                return  // response body starts with XML signature, fine
-            }
-        } catch (e: Exception) {
-            logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
-        }
-
-        // non-XML response body
-        throw DavException.fromResponse(
-            message = "Received non-XML 207 Multi-Status",
-            response = httpResponse
-        )
-    }
-
-    /**
      * Processes a Multi-Status response.
      *
      * The [response] must still be open (its body not yet closed) when the returned [Flow] is
@@ -776,13 +721,59 @@ open class DavResource(
     }
 
     /**
-     * Sends a request and processes its Multi-Status response, following up to [MAX_REDIRECTS] redirects.
-     * Combines [followRedirects] and [processMultiStatus] into a single [Flow] — the request is only
-     * sent once it's collected.
+     * Validates a 207 Multi-Status response.
      *
-     * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
+     * @param httpResponse  response that will be checked for Multi-Status
+     * @param bodyChannel   response body channel that will be peeked into in order to
+     *                      determine whether it's XML
      *
-     * @return flow of every [MultiStatusItem] found in the Multi-Status response
+     * @throws DavException if the response is not a Multi-Status response with XML body
+     */
+    suspend fun assertMultiStatus(httpResponse: HttpResponse, bodyChannel: ByteReadChannel) {
+        if (httpResponse.status != HttpStatusCode.MultiStatus)
+            throw DavException.fromResponse(
+                message = "Expected 207 Multi-Status, got ${httpResponse.status}",
+                response = httpResponse,
+                responseBodyChannel = bodyChannel
+            )
+
+        val contentType = httpResponse.contentType()
+        if (contentType == null) {
+            logger.warning("Received 207 Multi-Status without Content-Type, assuming XML")
+            return  // supposed XML response body, fine
+        }
+
+        if (contentType.isXml())
+            return  // reported XML response body, fine
+
+        /* Content-Type is not application/xml or text/xml although that is expected here.
+           Some broken servers return an XML response with some other MIME type. So we try to see
+           whether the response is maybe XML although the Content-Type is something else. */
+        try {
+            val firstBytes = bodyChannel.peek(XML_SIGNATURE.size)
+            if (firstBytes == XML_SIGNATURE) {
+                logger.warning("Received 207 Multi-Status that seems to be XML but has MIME type $contentType")
+                return  // response body starts with XML signature, fine
+            }
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Couldn't scan for XML signature", e)
+        }
+
+        // non-XML response body
+        throw DavException.fromResponse(
+            message = "Received non-XML 207 Multi-Status",
+            response = httpResponse
+        )
+    }
+
+    /**
+     * Executes a request and processes the response as a flow of multi-status items. Follows redirects.
+     *
+     * @param prepareRequest A suspending function that prepares and returns an HttpStatement for the request.
+     * @return A Flow emitting MultiStatusItem objects from the response.
+     *
+     * @throws HttpException on HTTP error
+     * @throws DavException on WebDAV error (for instance, when the response is not a Multi-Status response)
      */
     protected fun multiStatusFlow(prepareRequest: suspend () -> HttpStatement): Flow<MultiStatusItem> = flow {
         followRedirects(prepareRequest) { response ->

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -143,7 +143,10 @@ open class DavResource(
     }
 
     /**
-     * URL of this resource (changes when being redirected by server)
+     * URL of this resource (changes when being redirected by server).
+     *
+     * `Flow`-returning methods read this lazily at collection time — collecting several out of
+     * build order can race with a redirect. Known limitation, accepted for now.
      */
     var location: Url = location
         private set             // allow internal modification only (for redirects)
@@ -477,7 +480,7 @@ open class DavResource(
      * @param depth    "Depth" header to send (-1 for `infinity`)
      * @param reqProp  properties to request
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -524,7 +527,7 @@ open class DavResource(
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
      * @param removeProperties  list of names of properties that shall be removed
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error
@@ -559,7 +562,7 @@ open class DavResource(
      *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
      *
-     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable)
+     * @return cold flow of [MultiStatusItem]s found in the Multi-Status response (collect while [httpClient] is usable; see [location])
      *
      * @throws IOException on I/O error
      * @throws HttpException on HTTP error

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -474,7 +474,7 @@ open class DavResource(
      *
      * Follows up to [MAX_REDIRECTS] redirects.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * The request is only sent once the [Flow] is collected —
      * collect it while [httpClient] is still open.
      *
      * @param depth    "Depth" header to send (-1 for `infinity`)
@@ -524,7 +524,7 @@ open class DavResource(
      * Currently expects a 207 Multi-Status response although servers are allowed to
      * return other values, too.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * The request is only sent once the [Flow] is collected —
      * collect it while [httpClient] is still open.
      *
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
@@ -563,7 +563,7 @@ open class DavResource(
      *
      * Expects a 207 Multi-Status response.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * The request is only sent once the [Flow] is collected —
      * collect it while [httpClient] is still open.
      *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
@@ -778,7 +778,7 @@ open class DavResource(
     /**
      * Sends a request and processes its Multi-Status response, following up to [MAX_REDIRECTS] redirects.
      * Combines [followRedirects] and [processMultiStatus] into a single [Flow] — the request is only
-     * sent (and the flow only throws) once it's collected.
+     * sent once it's collected.
      *
      * @param prepareRequest    prepares the request (can be called multiple times with updated [location])
      *

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -62,7 +62,6 @@ import java.io.StringWriter
 import java.util.logging.Level
 import java.util.logging.Logger
 
-
 /**
  * Represents a WebDAV resource at the given location and allows WebDAV
  * requests to be performed on this resource.
@@ -475,7 +474,8 @@ open class DavResource(
      *
      * Follows up to [MAX_REDIRECTS] redirects.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * collect it while [httpClient] is still open.
      *
      * @param depth    "Depth" header to send (-1 for `infinity`)
      * @param reqProp  properties to request
@@ -524,7 +524,8 @@ open class DavResource(
      * Currently expects a 207 Multi-Status response although servers are allowed to
      * return other values, too.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * collect it while [httpClient] is still open.
      *
      * @param setProperties     map of properties that shall be set (values currently have to be strings)
      * @param removeProperties  list of names of properties that shall be removed
@@ -562,7 +563,8 @@ open class DavResource(
      *
      * Expects a 207 Multi-Status response.
      *
-     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected.
+     * The request is only sent (and the returned [Flow] only throws) once the [Flow] is collected —
+     * collect it while [httpClient] is still open.
      *
      * @param search    search request body (in XML format; like `DAV:searchrequest` or `DAV:query-schema-discovery`)
      *

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/DavResource.kt
@@ -145,8 +145,8 @@ open class DavResource(
     /**
      * URL of this resource (changes when being redirected by server).
      *
-     * `Flow`-returning methods read this lazily at collection time — collecting several out of
-     * build order can race with a redirect. Known limitation, accepted for now.
+     * `Flow`-returning methods read this lazily at collection time — collecting several flows
+     * concurrently can race withs redirects, see #209.
      */
     var location: Url = location
         private set             // allow internal modification only (for redirects)
@@ -773,6 +773,7 @@ open class DavResource(
      * @param prepareRequest A suspending function that prepares and returns an HttpStatement for the request.
      * @return A Flow emitting MultiStatusItem objects from the response.
      *
+     * @throws IOException on I/O error
      * @throws HttpException on HTTP error
      * @throws DavException on WebDAV error (for instance, when the response is not a Multi-Status response)
      */

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
@@ -29,8 +29,8 @@ sealed interface MultiStatusItem {
     ) : MultiStatusItem
 
     /**
-     * A property found directly under `<multistatus>`, outside any `<response>` element
-     * (for instance `sync-token`).
+     * A property found directly under `<multistatus>`, outside any `<response>` element,
+     * like `sync-token` (see RFC 6578 6.4 DAV:multistatus XML Element).
      */
     data class ExtraProperty(
         val property: Property

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
@@ -18,6 +18,14 @@ import at.bitfire.dav4jvm.Property
 sealed interface MultiStatusItem {
 
     /**
+     * A property found directly under `<multistatus>`, outside any `<response>` element,
+     * like `sync-token` (see RFC 6578 6.4 DAV:multistatus XML Element).
+     */
+    data class ExtraProperty(
+        val property: Property
+    ) : MultiStatusItem
+
+    /**
      * One `<response>` element of the Multi-Status body.
      *
      * @param response  the parsed response (including URL)
@@ -26,14 +34,6 @@ sealed interface MultiStatusItem {
     data class Response(
         val response: at.bitfire.dav4jvm.ktor.Response,
         val relation: at.bitfire.dav4jvm.ktor.Response.HrefRelation
-    ) : MultiStatusItem
-
-    /**
-     * A property found directly under `<multistatus>`, outside any `<response>` element,
-     * like `sync-token` (see RFC 6578 6.4 DAV:multistatus XML Element).
-     */
-    data class ExtraProperty(
-        val property: Property
     ) : MultiStatusItem
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusItem.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import at.bitfire.dav4jvm.Property
+
+/**
+ * One item emitted while parsing a WebDAV `<multistatus>` response.
+ */
+sealed interface MultiStatusItem {
+
+    /**
+     * One `<response>` element of the Multi-Status body.
+     *
+     * @param response  the parsed response (including URL)
+     * @param relation  relation of the response to the called resource
+     */
+    data class Response(
+        val response: at.bitfire.dav4jvm.ktor.Response,
+        val relation: at.bitfire.dav4jvm.ktor.Response.HrefRelation
+    ) : MultiStatusItem
+
+    /**
+     * A property found directly under `<multistatus>`, outside any `<response>` element
+     * (for instance `sync-token`).
+     */
+    data class ExtraProperty(
+        val property: Property
+    ) : MultiStatusItem
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusParser.kt
@@ -35,15 +35,17 @@ class MultiStatusParser(
         val depth = parser.depth
         var eventType = parser.eventType
         while (!(eventType == XmlPullParser.END_TAG && parser.depth == depth)) {
-            if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
-                when (parser.propertyName()) {
+            if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1) {
+                val item = when (parser.propertyName()) {
                     WebDAV.Response ->
-                        responseParser.parseResponse(parser, collector)
+                        responseParser.parseResponse(parser)
                     WebDAV.SyncToken ->
-                        XmlReader(parser).readText()?.let {
-                            collector.emit(MultiStatusItem.ExtraProperty(SyncToken(it)))
-                        }
+                        XmlReader(parser).readText()?.let { MultiStatusItem.ExtraProperty(SyncToken(it)) }
+                    else -> null
                 }
+                if (item != null)
+                    collector.emit(item)
+            }
             eventType = parser.next()
         }
     }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/MultiStatusParser.kt
@@ -10,12 +10,12 @@
 
 package at.bitfire.dav4jvm.ktor
 
-import at.bitfire.dav4jvm.Property
 import at.bitfire.dav4jvm.XmlReader
 import at.bitfire.dav4jvm.XmlUtils.propertyName
 import at.bitfire.dav4jvm.property.webdav.SyncToken
 import at.bitfire.dav4jvm.property.webdav.WebDAV
 import io.ktor.http.Url
+import kotlinx.coroutines.flow.FlowCollector
 import org.xmlpull.v1.XmlPullParser
 
 /**
@@ -24,12 +24,10 @@ import org.xmlpull.v1.XmlPullParser
  * @param location  location of the request (used to resolve possible relative `<href>` in responses)
  */
 class MultiStatusParser(
-    private val location: Url,
-    private val callback: MultiResponseCallback
+    private val location: Url
 ) {
 
-    suspend fun parseResponse(parser: XmlPullParser): List<Property> {
-        val responseProperties = mutableListOf<Property>()
+    suspend fun parseResponse(parser: XmlPullParser, collector: FlowCollector<MultiStatusItem>) {
         val responseParser = ResponseParser(location)
 
         // <!ELEMENT multistatus (response*, responsedescription?,
@@ -40,16 +38,14 @@ class MultiStatusParser(
             if (eventType == XmlPullParser.START_TAG && parser.depth == depth + 1)
                 when (parser.propertyName()) {
                     WebDAV.Response ->
-                        responseParser.parseResponse(parser, callback)
+                        responseParser.parseResponse(parser, collector)
                     WebDAV.SyncToken ->
                         XmlReader(parser).readText()?.let {
-                            responseProperties += SyncToken(it)
+                            collector.emit(MultiStatusItem.ExtraProperty(SyncToken(it)))
                         }
                 }
             eventType = parser.next()
         }
-
-        return responseProperties
     }
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
@@ -20,7 +20,6 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
-import kotlinx.coroutines.flow.FlowCollector
 import org.jetbrains.annotations.VisibleForTesting
 import org.xmlpull.v1.XmlPullParser
 import java.util.logging.Level
@@ -39,19 +38,21 @@ class ResponseParser(
         get() = Logger.getLogger(javaClass.name)
 
     /**
-     * Parses an XML response element and emits a [MultiStatusItem.Response] for it (when it has a `<href>`).
+     * Parses an XML response element and returns the [MultiStatusItem.Response] for it, or `null`
+     * if it doesn't have a `<href>`.
      *
      * If the [at.bitfire.dav4jvm.property.webdav.ResourceType] of the queried resource is known (= was queried and returned by the server)
-     * and it contains [at.bitfire.dav4jvm.property.webdav.ResourceType.Companion.COLLECTION], the `href` of the emitted item will automatically
+     * and it contains [at.bitfire.dav4jvm.property.webdav.ResourceType.Companion.COLLECTION], the `href` of the returned item will automatically
      * have a trailing slash.
      *
      * So if you want PROPFIND results to have a trailing slash when they are collections, make sure
      * that you query [at.bitfire.dav4jvm.property.webdav.ResourceType].
      *
      * @param parser    XML document to parse
-     * @param collector collector that the parsed item is emitted into
+     *
+     * @return the parsed [MultiStatusItem.Response], or `null` if the response has no `<href>`
      */
-    suspend fun parseResponse(parser: XmlPullParser, collector: FlowCollector<MultiStatusItem>) {
+    fun parseResponse(parser: XmlPullParser): MultiStatusItem.Response? {
         val depth = parser.depth
 
         var hrefOrNull: Url? = null
@@ -80,7 +81,7 @@ class ResponseParser(
 
         if (hrefOrNull == null) {
             logger.warning("Ignoring XML response element without valid href")
-            return
+            return null
         }
         var href: Url = hrefOrNull      // guaranteed to be not null
 
@@ -127,18 +128,16 @@ class ResponseParser(
             }
         }
 
-        collector.emit(
-            MultiStatusItem.Response(
-                response = Response(
-                    requestedUrl = location,
-                    href = href,
-                    status = status,
-                    propstat = propStat,
-                    error = error,
-                    newLocation = newLocation
-                ),
-                relation = relation
-            )
+        return MultiStatusItem.Response(
+            response = Response(
+                requestedUrl = location,
+                href = href,
+                status = status,
+                propstat = propStat,
+                error = error,
+                newLocation = newLocation
+            ),
+            relation = relation
         )
     }
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/ResponseParser.kt
@@ -20,6 +20,7 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
+import kotlinx.coroutines.flow.FlowCollector
 import org.jetbrains.annotations.VisibleForTesting
 import org.xmlpull.v1.XmlPullParser
 import java.util.logging.Level
@@ -38,20 +39,19 @@ class ResponseParser(
         get() = Logger.getLogger(javaClass.name)
 
     /**
-     * Parses an XML response element and calls the [callback] for it (when it has a `<href>`).
-     * The arguments of the [MultiResponseCallback.onResponse] are set accordingly.
+     * Parses an XML response element and emits a [MultiStatusItem.Response] for it (when it has a `<href>`).
      *
      * If the [at.bitfire.dav4jvm.property.webdav.ResourceType] of the queried resource is known (= was queried and returned by the server)
-     * and it contains [at.bitfire.dav4jvm.property.webdav.ResourceType.Companion.COLLECTION], the `href` property of the callback will automatically
+     * and it contains [at.bitfire.dav4jvm.property.webdav.ResourceType.Companion.COLLECTION], the `href` of the emitted item will automatically
      * have a trailing slash.
      *
      * So if you want PROPFIND results to have a trailing slash when they are collections, make sure
      * that you query [at.bitfire.dav4jvm.property.webdav.ResourceType].
      *
      * @param parser    XML document to parse
-     * @param callback  callback to be called for every multistatus `<response>`
+     * @param collector collector that the parsed item is emitted into
      */
-    suspend fun parseResponse(parser: XmlPullParser, callback: MultiResponseCallback) {
+    suspend fun parseResponse(parser: XmlPullParser, collector: FlowCollector<MultiStatusItem>) {
         val depth = parser.depth
 
         var hrefOrNull: Url? = null
@@ -127,16 +127,18 @@ class ResponseParser(
             }
         }
 
-        callback.onResponse(
-            Response(
-                requestedUrl = location,
-                href = href,
-                status = status,
-                propstat = propStat,
-                error = error,
-                newLocation = newLocation
-            ),
-            relation
+        collector.emit(
+            MultiStatusItem.Response(
+                response = Response(
+                    requestedUrl = location,
+                    href = href,
+                    status = status,
+                    propstat = propStat,
+                    error = error,
+                    newLocation = newLocation
+                ),
+                relation = relation
+            )
         )
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
@@ -21,6 +21,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import io.ktor.http.withCharset
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -48,7 +49,7 @@ class DavAddressBookTest {
     @Test
     fun `addressbookQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).addressbookQuery().collect { }
+        davAddressBook(engine).addressbookQuery().toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
@@ -60,7 +61,7 @@ class DavAddressBookTest {
     @Test
     fun `addressbookQuery request body contains query and filter`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).addressbookQuery().collect { }
+        davAddressBook(engine).addressbookQuery().toList()
         val body = requestBody(engine)
         assertTrue(body.contains("CARD:addressbook-query"))
         assertTrue(body.contains("<getetag />"))
@@ -70,7 +71,7 @@ class DavAddressBookTest {
     @Test
     fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).multiget(listOf(sampleUrl)).collect { }
+        davAddressBook(engine).multiget(listOf(sampleUrl)).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -84,7 +85,7 @@ class DavAddressBookTest {
         val engine = minimalMultiStatus()
         val url1 = Url("http://127.0.0.1/dav/contact1.vcf")
         val url2 = Url("http://127.0.0.1/dav/contact2.vcf")
-        davAddressBook(engine).multiget(listOf(url1, url2)).collect { }
+        davAddressBook(engine).multiget(listOf(url1, url2)).toList()
         val body = requestBody(engine)
         assertTrue(body.contains("CARD:addressbook-multiget"))
         assertTrue(body.contains("<href>/dav/contact1.vcf</href>"))
@@ -98,7 +99,7 @@ class DavAddressBookTest {
     @Test
     fun `multiget with contentType adds attributes to address-data`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).multiget(listOf(sampleUrl), contentType = "text/vcard", version = "4.0").collect { }
+        davAddressBook(engine).multiget(listOf(sampleUrl), contentType = "text/vcard", version = "4.0").toList()
         val body = requestBody(engine)
         assertTrue(body.contains("content-type=\"text/vcard\""))
         assertTrue(body.contains("version=\"4.0\""))

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavAddressBookTest.kt
@@ -48,7 +48,7 @@ class DavAddressBookTest {
     @Test
     fun `addressbookQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).addressbookQuery { _, _ -> }
+        davAddressBook(engine).addressbookQuery().collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
@@ -60,7 +60,7 @@ class DavAddressBookTest {
     @Test
     fun `addressbookQuery request body contains query and filter`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).addressbookQuery { _, _ -> }
+        davAddressBook(engine).addressbookQuery().collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("CARD:addressbook-query"))
         assertTrue(body.contains("<getetag />"))
@@ -70,7 +70,7 @@ class DavAddressBookTest {
     @Test
     fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).multiget(listOf(sampleUrl)) { _, _ -> }
+        davAddressBook(engine).multiget(listOf(sampleUrl)).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -84,7 +84,7 @@ class DavAddressBookTest {
         val engine = minimalMultiStatus()
         val url1 = Url("http://127.0.0.1/dav/contact1.vcf")
         val url2 = Url("http://127.0.0.1/dav/contact2.vcf")
-        davAddressBook(engine).multiget(listOf(url1, url2)) { _, _ -> }
+        davAddressBook(engine).multiget(listOf(url1, url2)).collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("CARD:addressbook-multiget"))
         assertTrue(body.contains("<href>/dav/contact1.vcf</href>"))
@@ -98,7 +98,7 @@ class DavAddressBookTest {
     @Test
     fun `multiget with contentType adds attributes to address-data`() = runTest {
         val engine = minimalMultiStatus()
-        davAddressBook(engine).multiget(listOf(sampleUrl), contentType = "text/vcard", version = "4.0") { _, _ -> }
+        davAddressBook(engine).multiget(listOf(sampleUrl), contentType = "text/vcard", version = "4.0").collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("content-type=\"text/vcard\""))
         assertTrue(body.contains("version=\"4.0\""))

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
@@ -22,6 +22,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.headersOf
 import io.ktor.http.withCharset
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -55,7 +56,7 @@ class DavCalendarTest {
             "VEVENT",
             start = Instant.ofEpochSecond(784111777),
             end = Instant.ofEpochSecond(1689324577)
-        ).collect { }
+        ).toList()
         assertEquals(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                     "<CAL:calendar-query xmlns=\"DAV:\" xmlns:CAL=\"urn:ietf:params:xml:ns:caldav\">" +
@@ -77,14 +78,14 @@ class DavCalendarTest {
     @Test
     fun `calendarQuery without time range omits time-range element`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).collect { }
+        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).toList()
         assertFalse(requestBody(engine).contains("<CAL:time-range"))
     }
 
     @Test
     fun `calendarQuery custom component name used in comp-filter`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VTODO", start = null, end = null).collect { }
+        davCalendar(engine).calendarQuery("VTODO", start = null, end = null).toList()
         assertTrue(requestBody(engine).contains("name=\"VTODO\""))
     }
 
@@ -94,7 +95,7 @@ class DavCalendarTest {
         davCalendar(engine).calendarQuery(
             "VEVENT", start = null, end = null,
             props = setOf(WebDAV.GetETag, WebDAV.DisplayName)
-        ).collect { }
+        ).toList()
         val body = requestBody(engine)
         assertTrue(body.contains("<getetag />"))
         assertTrue(body.contains("<displayname />"))
@@ -103,7 +104,7 @@ class DavCalendarTest {
     @Test
     fun `calendarQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).collect { }
+        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
@@ -115,7 +116,7 @@ class DavCalendarTest {
     @Test
     fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).multiget(listOf(sampleUrl)).collect { }
+        davCalendar(engine).multiget(listOf(sampleUrl)).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertNull(headers[HttpHeaders.Depth])
@@ -129,7 +130,7 @@ class DavCalendarTest {
         val engine = minimalMultiStatus()
         val url1 = Url("http://127.0.0.1/dav/cal1.ics")
         val url2 = Url("http://127.0.0.1/dav/cal2.ics")
-        davCalendar(engine).multiget(listOf(url1, url2)).collect { }
+        davCalendar(engine).multiget(listOf(url1, url2)).toList()
         val body = requestBody(engine)
         assertTrue(body.contains("CAL:calendar-multiget"))
         assertTrue(body.contains("<href>/dav/cal1.ics</href>"))
@@ -141,7 +142,7 @@ class DavCalendarTest {
     @Test
     fun `multiget with contentType adds attributes to calendar-data`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).multiget(listOf(sampleUrl), contentType = "text/calendar", version = "2.0").collect { }
+        davCalendar(engine).multiget(listOf(sampleUrl), contentType = "text/calendar", version = "2.0").toList()
         val body = requestBody(engine)
         assertTrue(body.contains("content-type=\"text/calendar\""))
         assertTrue(body.contains("version=\"2.0\""))

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCalendarTest.kt
@@ -55,7 +55,7 @@ class DavCalendarTest {
             "VEVENT",
             start = Instant.ofEpochSecond(784111777),
             end = Instant.ofEpochSecond(1689324577)
-        ) { _, _ -> }
+        ).collect { }
         assertEquals(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
                     "<CAL:calendar-query xmlns=\"DAV:\" xmlns:CAL=\"urn:ietf:params:xml:ns:caldav\">" +
@@ -77,14 +77,14 @@ class DavCalendarTest {
     @Test
     fun `calendarQuery without time range omits time-range element`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null) { _, _ -> }
+        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).collect { }
         assertFalse(requestBody(engine).contains("<CAL:time-range"))
     }
 
     @Test
     fun `calendarQuery custom component name used in comp-filter`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VTODO", start = null, end = null) { _, _ -> }
+        davCalendar(engine).calendarQuery("VTODO", start = null, end = null).collect { }
         assertTrue(requestBody(engine).contains("name=\"VTODO\""))
     }
 
@@ -94,7 +94,7 @@ class DavCalendarTest {
         davCalendar(engine).calendarQuery(
             "VEVENT", start = null, end = null,
             props = setOf(WebDAV.GetETag, WebDAV.DisplayName)
-        ) { _, _ -> }
+        ).collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("<getetag />"))
         assertTrue(body.contains("<displayname />"))
@@ -103,7 +103,7 @@ class DavCalendarTest {
     @Test
     fun `calendarQuery sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null) { _, _ -> }
+        davCalendar(engine).calendarQuery("VEVENT", start = null, end = null).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("1", headers[HttpHeaders.Depth])
@@ -115,7 +115,7 @@ class DavCalendarTest {
     @Test
     fun `multiget sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).multiget(listOf(sampleUrl)) { _, _ -> }
+        davCalendar(engine).multiget(listOf(sampleUrl)).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertNull(headers[HttpHeaders.Depth])
@@ -129,7 +129,7 @@ class DavCalendarTest {
         val engine = minimalMultiStatus()
         val url1 = Url("http://127.0.0.1/dav/cal1.ics")
         val url2 = Url("http://127.0.0.1/dav/cal2.ics")
-        davCalendar(engine).multiget(listOf(url1, url2)) { _, _ -> }
+        davCalendar(engine).multiget(listOf(url1, url2)).collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("CAL:calendar-multiget"))
         assertTrue(body.contains("<href>/dav/cal1.ics</href>"))
@@ -141,7 +141,7 @@ class DavCalendarTest {
     @Test
     fun `multiget with contentType adds attributes to calendar-data`() = runTest {
         val engine = minimalMultiStatus()
-        davCalendar(engine).multiget(listOf(sampleUrl), contentType = "text/calendar", version = "2.0") { _, _ -> }
+        davCalendar(engine).multiget(listOf(sampleUrl), contentType = "text/calendar", version = "2.0").collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("content-type=\"text/calendar\""))
         assertTrue(body.contains("version=\"2.0\""))

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
@@ -59,6 +59,11 @@ class DavCollectionTest {
     private suspend fun requestBody(engine: MockEngine) =
         engine.requestHistory.last().body.toByteArray().toString(Charsets.UTF_8)
 
+    private fun List<MultiStatusItem>.syncToken(): SyncToken? =
+        filterIsInstance<MultiStatusItem.ExtraProperty>().map { it.property }
+            .filterIsInstance<SyncToken>()
+            .firstOrNull()
+
 
     @Test
     fun `reportChanges initial sync parses all members`() = runTest {
@@ -155,9 +160,7 @@ class DavCollectionTest {
         }
         assertEquals(3, nrCalled)
 
-        val syncToken = items.filterIsInstance<MultiStatusItem.ExtraProperty>()
-            .map { it.property }.filterIsInstance<SyncToken>().firstOrNull()
-        assertEquals("http://example.com/ns/sync/1234", syncToken?.token)
+        assertEquals("http://example.com/ns/sync/1234", items.syncToken()?.token)
     }
 
     @Test
@@ -241,9 +244,7 @@ class DavCollectionTest {
         }
         assertEquals(4, nrCalled)
 
-        val syncToken = items.filterIsInstance<MultiStatusItem.ExtraProperty>()
-            .map { it.property }.filterIsInstance<SyncToken>().firstOrNull()
-        assertEquals("http://example.com/ns/sync/1233", syncToken?.token)
+        assertEquals("http://example.com/ns/sync/1233", items.syncToken()?.token)
     }
 
     @Test

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
@@ -119,38 +119,47 @@ class DavCollectionTest {
         }
         val collection = davCollection(mockEngine)
         var nrCalled = 0
-        val result = collection.reportChanges(null, false, null, WebDAV.GetETag) { response, relation ->
-            when (response.href) {
-                sampleUrl.resolve("/dav/test.doc") -> {
-                    assertTrue(response.isSuccess())
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    val eTag = response[GetETag::class.java]
-                    assertEquals("00001-abcd1", eTag!!.eTag)
-                    assertFalse(eTag.weak)
-                    nrCalled++
-                }
+        var syncToken: SyncToken? = null
+        collection.reportChanges(null, false, null, WebDAV.GetETag).collect { item ->
+            when (item) {
+                is MultiStatusItem.ExtraProperty ->
+                    (item.property as? SyncToken)?.let { syncToken = it }
 
-                sampleUrl.resolve("/dav/vcard.vcf") -> {
-                    assertTrue(response.isSuccess())
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    val eTag = response[GetETag::class.java]
-                    assertEquals("00002-abcd1", eTag!!.eTag)
-                    assertFalse(eTag.weak)
-                    nrCalled++
-                }
+                is MultiStatusItem.Response -> {
+                    val (response, relation) = item
+                    when (response.href) {
+                        sampleUrl.resolve("/dav/test.doc") -> {
+                            assertTrue(response.isSuccess())
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            val eTag = response[GetETag::class.java]
+                            assertEquals("00001-abcd1", eTag!!.eTag)
+                            assertFalse(eTag.weak)
+                            nrCalled++
+                        }
 
-                sampleUrl.resolve("/dav/calendar.ics") -> {
-                    assertTrue(response.isSuccess())
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    val eTag = response[GetETag::class.java]
-                    assertEquals("00003-abcd1", eTag!!.eTag)
-                    assertFalse(eTag.weak)
-                    nrCalled++
+                        sampleUrl.resolve("/dav/vcard.vcf") -> {
+                            assertTrue(response.isSuccess())
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            val eTag = response[GetETag::class.java]
+                            assertEquals("00002-abcd1", eTag!!.eTag)
+                            assertFalse(eTag.weak)
+                            nrCalled++
+                        }
+
+                        sampleUrl.resolve("/dav/calendar.ics") -> {
+                            assertTrue(response.isSuccess())
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            val eTag = response[GetETag::class.java]
+                            assertEquals("00003-abcd1", eTag!!.eTag)
+                            assertFalse(eTag.weak)
+                            nrCalled++
+                        }
+                    }
                 }
             }
         }
         assertEquals(3, nrCalled)
-        assertEquals("http://example.com/ns/sync/1234", result.filterIsInstance<SyncToken>().first().token)
+        assertEquals("http://example.com/ns/sync/1234", syncToken?.token)
     }
 
     @Test
@@ -194,42 +203,51 @@ class DavCollectionTest {
         }
         val collection = davCollection(mockEngine)
         var nrCalled = 0
-        val result = collection.reportChanges(null, false, null, WebDAV.GetETag) { response, relation ->
-            when (response.href) {
-                sampleUrl.resolve("/dav/test.doc") -> {
-                    assertTrue(response.isSuccess())
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    val eTag = response[GetETag::class.java]
-                    assertEquals("00001-abcd1", eTag?.eTag)
-                    assertTrue(eTag?.weak == false)
-                    nrCalled++
-                }
+        var syncToken: SyncToken? = null
+        collection.reportChanges(null, false, null, WebDAV.GetETag).collect { item ->
+            when (item) {
+                is MultiStatusItem.ExtraProperty ->
+                    (item.property as? SyncToken)?.let { syncToken = it }
 
-                sampleUrl.resolve("/dav/vcard.vcf") -> {
-                    assertTrue(response.isSuccess())
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    val eTag = response[GetETag::class.java]
-                    assertEquals("00002-abcd1", eTag?.eTag)
-                    assertTrue(eTag?.weak == false)
-                    nrCalled++
-                }
+                is MultiStatusItem.Response -> {
+                    val (response, relation) = item
+                    when (response.href) {
+                        sampleUrl.resolve("/dav/test.doc") -> {
+                            assertTrue(response.isSuccess())
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            val eTag = response[GetETag::class.java]
+                            assertEquals("00001-abcd1", eTag?.eTag)
+                            assertTrue(eTag?.weak == false)
+                            nrCalled++
+                        }
 
-                sampleUrl.resolve("/dav/removed.txt") -> {
-                    assertFalse(response.isSuccess())
-                    assertEquals(404, response.status?.value)
-                    assertEquals(Response.HrefRelation.MEMBER, relation)
-                    nrCalled++
-                }
+                        sampleUrl.resolve("/dav/vcard.vcf") -> {
+                            assertTrue(response.isSuccess())
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            val eTag = response[GetETag::class.java]
+                            assertEquals("00002-abcd1", eTag?.eTag)
+                            assertTrue(eTag?.weak == false)
+                            nrCalled++
+                        }
 
-                sampleUrl.resolve("/dav/") -> {
-                    assertFalse(response.isSuccess())
-                    assertEquals(507, response.status?.value)
-                    assertEquals(Response.HrefRelation.SELF, relation)
-                    nrCalled++
+                        sampleUrl.resolve("/dav/removed.txt") -> {
+                            assertFalse(response.isSuccess())
+                            assertEquals(404, response.status?.value)
+                            assertEquals(Response.HrefRelation.MEMBER, relation)
+                            nrCalled++
+                        }
+
+                        sampleUrl.resolve("/dav/") -> {
+                            assertFalse(response.isSuccess())
+                            assertEquals(507, response.status?.value)
+                            assertEquals(Response.HrefRelation.SELF, relation)
+                            nrCalled++
+                        }
+                    }
                 }
             }
         }
-        assertEquals("http://example.com/ns/sync/1233", result.filterIsInstance<SyncToken>().first().token)
+        assertEquals("http://example.com/ns/sync/1233", syncToken?.token)
         assertEquals(4, nrCalled)
     }
 
@@ -247,7 +265,7 @@ class DavCollectionTest {
         }
         val collection = davCollection(mockEngine)
         try {
-            collection.reportChanges("http://example.com/ns/sync/1232", false, 100, WebDAV.GetETag) { _, _ -> }
+            collection.reportChanges("http://example.com/ns/sync/1232", false, 100, WebDAV.GetETag).collect { }
             fail("Expected HttpException")
         } catch (e: HttpException) {
             assertEquals(HttpStatusCode.InsufficientStorage.value, e.statusCode)
@@ -259,7 +277,7 @@ class DavCollectionTest {
     @Test
     fun `reportChanges sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }
+        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -271,7 +289,7 @@ class DavCollectionTest {
     @Test
     fun `reportChanges null sync token sends empty sync-token element`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag) { _, _ -> }
+        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).collect { }
         val body = requestBody(engine)
         assertTrue(body.contains("<sync-token />"))
         assertTrue(body.contains("<sync-level>1</sync-level>"))
@@ -282,21 +300,21 @@ class DavCollectionTest {
     @Test
     fun `reportChanges non-null sync token included in body`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges("http://example.com/ns/sync/42", false, null, WebDAV.GetETag) { _, _ -> }
+        davCollection(engine).reportChanges("http://example.com/ns/sync/42", false, null, WebDAV.GetETag).collect { }
         assertTrue(requestBody(engine).contains("<sync-token>http://example.com/ns/sync/42</sync-token>"))
     }
 
     @Test
     fun `reportChanges infiniteDepth sends sync-level infinite`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, true, null, WebDAV.GetETag) { _, _ -> }
+        davCollection(engine).reportChanges(null, true, null, WebDAV.GetETag).collect { }
         assertTrue(requestBody(engine).contains("<sync-level>infinite</sync-level>"))
     }
 
     @Test
     fun `reportChanges with limit includes nresults element`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, 50, WebDAV.GetETag) { _, _ -> }
+        davCollection(engine).reportChanges(null, false, 50, WebDAV.GetETag).collect { }
         assertTrue(requestBody(engine).contains("<nresults>50</nresults>"))
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavCollectionTest.kt
@@ -33,6 +33,7 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.headersOf
 import io.ktor.http.withCharset
 import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -118,47 +119,44 @@ class DavCollectionTest {
             )
         }
         val collection = davCollection(mockEngine)
+        val items = collection.reportChanges(null, false, null, WebDAV.GetETag).toList()
+
         var nrCalled = 0
-        var syncToken: SyncToken? = null
-        collection.reportChanges(null, false, null, WebDAV.GetETag).collect { item ->
-            when (item) {
-                is MultiStatusItem.ExtraProperty ->
-                    (item.property as? SyncToken)?.let { syncToken = it }
+        items.filterIsInstance<MultiStatusItem.Response>().forEach { item ->
+            val (response, relation) = item
+            when (response.href) {
+                sampleUrl.resolve("/dav/test.doc") -> {
+                    assertTrue(response.isSuccess())
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    val eTag = response[GetETag::class.java]
+                    assertEquals("00001-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
+                    nrCalled++
+                }
 
-                is MultiStatusItem.Response -> {
-                    val (response, relation) = item
-                    when (response.href) {
-                        sampleUrl.resolve("/dav/test.doc") -> {
-                            assertTrue(response.isSuccess())
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            val eTag = response[GetETag::class.java]
-                            assertEquals("00001-abcd1", eTag!!.eTag)
-                            assertFalse(eTag.weak)
-                            nrCalled++
-                        }
+                sampleUrl.resolve("/dav/vcard.vcf") -> {
+                    assertTrue(response.isSuccess())
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    val eTag = response[GetETag::class.java]
+                    assertEquals("00002-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
+                    nrCalled++
+                }
 
-                        sampleUrl.resolve("/dav/vcard.vcf") -> {
-                            assertTrue(response.isSuccess())
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            val eTag = response[GetETag::class.java]
-                            assertEquals("00002-abcd1", eTag!!.eTag)
-                            assertFalse(eTag.weak)
-                            nrCalled++
-                        }
-
-                        sampleUrl.resolve("/dav/calendar.ics") -> {
-                            assertTrue(response.isSuccess())
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            val eTag = response[GetETag::class.java]
-                            assertEquals("00003-abcd1", eTag!!.eTag)
-                            assertFalse(eTag.weak)
-                            nrCalled++
-                        }
-                    }
+                sampleUrl.resolve("/dav/calendar.ics") -> {
+                    assertTrue(response.isSuccess())
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    val eTag = response[GetETag::class.java]
+                    assertEquals("00003-abcd1", eTag!!.eTag)
+                    assertFalse(eTag.weak)
+                    nrCalled++
                 }
             }
         }
         assertEquals(3, nrCalled)
+
+        val syncToken = items.filterIsInstance<MultiStatusItem.ExtraProperty>()
+            .map { it.property }.filterIsInstance<SyncToken>().firstOrNull()
         assertEquals("http://example.com/ns/sync/1234", syncToken?.token)
     }
 
@@ -202,53 +200,50 @@ class DavCollectionTest {
             )
         }
         val collection = davCollection(mockEngine)
+        val items = collection.reportChanges(null, false, null, WebDAV.GetETag).toList()
+
         var nrCalled = 0
-        var syncToken: SyncToken? = null
-        collection.reportChanges(null, false, null, WebDAV.GetETag).collect { item ->
-            when (item) {
-                is MultiStatusItem.ExtraProperty ->
-                    (item.property as? SyncToken)?.let { syncToken = it }
+        items.filterIsInstance<MultiStatusItem.Response>().forEach { item ->
+            val (response, relation) = item
+            when (response.href) {
+                sampleUrl.resolve("/dav/test.doc") -> {
+                    assertTrue(response.isSuccess())
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    val eTag = response[GetETag::class.java]
+                    assertEquals("00001-abcd1", eTag?.eTag)
+                    assertTrue(eTag?.weak == false)
+                    nrCalled++
+                }
 
-                is MultiStatusItem.Response -> {
-                    val (response, relation) = item
-                    when (response.href) {
-                        sampleUrl.resolve("/dav/test.doc") -> {
-                            assertTrue(response.isSuccess())
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            val eTag = response[GetETag::class.java]
-                            assertEquals("00001-abcd1", eTag?.eTag)
-                            assertTrue(eTag?.weak == false)
-                            nrCalled++
-                        }
+                sampleUrl.resolve("/dav/vcard.vcf") -> {
+                    assertTrue(response.isSuccess())
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    val eTag = response[GetETag::class.java]
+                    assertEquals("00002-abcd1", eTag?.eTag)
+                    assertTrue(eTag?.weak == false)
+                    nrCalled++
+                }
 
-                        sampleUrl.resolve("/dav/vcard.vcf") -> {
-                            assertTrue(response.isSuccess())
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            val eTag = response[GetETag::class.java]
-                            assertEquals("00002-abcd1", eTag?.eTag)
-                            assertTrue(eTag?.weak == false)
-                            nrCalled++
-                        }
+                sampleUrl.resolve("/dav/removed.txt") -> {
+                    assertFalse(response.isSuccess())
+                    assertEquals(404, response.status?.value)
+                    assertEquals(Response.HrefRelation.MEMBER, relation)
+                    nrCalled++
+                }
 
-                        sampleUrl.resolve("/dav/removed.txt") -> {
-                            assertFalse(response.isSuccess())
-                            assertEquals(404, response.status?.value)
-                            assertEquals(Response.HrefRelation.MEMBER, relation)
-                            nrCalled++
-                        }
-
-                        sampleUrl.resolve("/dav/") -> {
-                            assertFalse(response.isSuccess())
-                            assertEquals(507, response.status?.value)
-                            assertEquals(Response.HrefRelation.SELF, relation)
-                            nrCalled++
-                        }
-                    }
+                sampleUrl.resolve("/dav/") -> {
+                    assertFalse(response.isSuccess())
+                    assertEquals(507, response.status?.value)
+                    assertEquals(Response.HrefRelation.SELF, relation)
+                    nrCalled++
                 }
             }
         }
-        assertEquals("http://example.com/ns/sync/1233", syncToken?.token)
         assertEquals(4, nrCalled)
+
+        val syncToken = items.filterIsInstance<MultiStatusItem.ExtraProperty>()
+            .map { it.property }.filterIsInstance<SyncToken>().firstOrNull()
+        assertEquals("http://example.com/ns/sync/1233", syncToken?.token)
     }
 
     @Test
@@ -265,7 +260,7 @@ class DavCollectionTest {
         }
         val collection = davCollection(mockEngine)
         try {
-            collection.reportChanges("http://example.com/ns/sync/1232", false, 100, WebDAV.GetETag).collect { }
+            collection.reportChanges("http://example.com/ns/sync/1232", false, 100, WebDAV.GetETag).toList()
             fail("Expected HttpException")
         } catch (e: HttpException) {
             assertEquals(HttpStatusCode.InsufficientStorage.value, e.statusCode)
@@ -277,7 +272,7 @@ class DavCollectionTest {
     @Test
     fun `reportChanges sends proper request`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).collect { }
+        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("REPORT"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -289,7 +284,7 @@ class DavCollectionTest {
     @Test
     fun `reportChanges null sync token sends empty sync-token element`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).collect { }
+        davCollection(engine).reportChanges(null, false, null, WebDAV.GetETag).toList()
         val body = requestBody(engine)
         assertTrue(body.contains("<sync-token />"))
         assertTrue(body.contains("<sync-level>1</sync-level>"))
@@ -300,21 +295,21 @@ class DavCollectionTest {
     @Test
     fun `reportChanges non-null sync token included in body`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges("http://example.com/ns/sync/42", false, null, WebDAV.GetETag).collect { }
+        davCollection(engine).reportChanges("http://example.com/ns/sync/42", false, null, WebDAV.GetETag).toList()
         assertTrue(requestBody(engine).contains("<sync-token>http://example.com/ns/sync/42</sync-token>"))
     }
 
     @Test
     fun `reportChanges infiniteDepth sends sync-level infinite`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, true, null, WebDAV.GetETag).collect { }
+        davCollection(engine).reportChanges(null, true, null, WebDAV.GetETag).toList()
         assertTrue(requestBody(engine).contains("<sync-level>infinite</sync-level>"))
     }
 
     @Test
     fun `reportChanges with limit includes nresults element`() = runTest {
         val engine = minimalMultiStatus()
-        davCollection(engine).reportChanges(null, false, 50, WebDAV.GetETag).collect { }
+        davCollection(engine).reportChanges(null, false, 50, WebDAV.GetETag).toList()
         assertTrue(requestBody(engine).contains("<nresults>50</nresults>"))
     }
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -466,7 +466,7 @@ class DavResourceTest {
         val dav = davResource(MockEngine { respondError(HttpStatusCode.InternalServerError) })
         var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType) { _, _ -> called = true }
+            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
             fail("Expected HttpException")
         } catch (_: HttpException) {
             assertFalse(called)
@@ -478,10 +478,23 @@ class DavResourceTest {
         val dav = davResource(MockEngine { respondOk() })
         var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType) { _, _ -> called = true }
+            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
             fail("Expected DavException")
         } catch (_: DavException) {
             assertFalse(called)
+        }
+    }
+
+    @Test
+    fun `propfind is not sent before flow is collected`() = runTest {
+        val dav = davResource(MockEngine { respondError(HttpStatusCode.InternalServerError) })
+        // building the flow must not trigger the request or throw
+        val flow = dav.propfind(0, WebDAV.ResourceType)
+        try {
+            flow.collect { }
+            fail("Expected HttpException")
+        } catch (_: HttpException) {
+            // expected only once the flow is collected
         }
     }
 
@@ -492,7 +505,7 @@ class DavResourceTest {
         })
         var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType) { _, _ -> called = true }
+            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
             fail("Expected DavException")
         } catch (_: DavException) {
             assertFalse(called)
@@ -509,7 +522,7 @@ class DavResourceTest {
         })
         var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType) { _, _ -> called = true }
+            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
             fail("Expected DavException")
         } catch (_: DavException) {
             assertFalse(called)
@@ -521,7 +534,7 @@ class DavResourceTest {
         val dav = davResource(propfindEngine("<test></test>"))
         var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType) { _, _ -> called = true }
+            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
             fail("Expected DavException")
         } catch (_: DavException) {
             assertFalse(called)
@@ -541,9 +554,10 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType) { response, relation ->
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertEquals(HttpStatusCode.InternalServerError, response.status)
+        dav.propfind(0, WebDAV.ResourceType).collect { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertEquals(HttpStatusCode.InternalServerError, item.response.status)
             called = true
         }
         assertTrue(called)
@@ -562,9 +576,10 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType) { response, relation ->
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertEquals(HttpStatusCode.Forbidden, response.status)
+        dav.propfind(0, WebDAV.ResourceType).collect { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertEquals(HttpStatusCode.Forbidden, item.response.status)
             called = true
         }
         assertTrue(called)
@@ -586,10 +601,11 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType) { response, relation ->
+        dav.propfind(0, WebDAV.ResourceType).collect { item ->
+            item as MultiStatusItem.Response
             called = true
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertTrue(response.properties.filterIsInstance<ResourceType>().isEmpty())
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertTrue(item.response.properties.filterIsInstance<ResourceType>().isEmpty())
         }
         assertTrue(called)
     }
@@ -597,7 +613,7 @@ class DavResourceTest {
     @Test
     fun `propfind no response elements callback not called`() = runTest {
         val dav = davResource(propfindEngine("<multistatus xmlns='DAV:'></multistatus>"))
-        dav.propfind(0, WebDAV.ResourceType) { _, _ -> fail("Shouldn't be called") }
+        dav.propfind(0, WebDAV.ResourceType).collect { fail("Shouldn't be called") }
     }
 
     @Test
@@ -613,11 +629,12 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType) { response, relation ->
+        dav.propfind(0, WebDAV.ResourceType).collect { item ->
+            item as MultiStatusItem.Response
             called = true
-            assertTrue(response.isSuccess())
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertEquals(0, response.properties.size)
+            assertTrue(item.response.isSuccess())
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertEquals(0, item.response.properties.size)
         }
         assertTrue(called)
     }
@@ -641,11 +658,12 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName) { response, relation ->
+        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
+            item as MultiStatusItem.Response
             called = true
-            assertTrue(response.isSuccess())
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertEquals("My DAV Collection", response[DisplayName::class.java]?.displayName)
+            assertTrue(item.response.isSuccess())
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertEquals("My DAV Collection", item.response[DisplayName::class.java]?.displayName)
         }
         assertTrue(called)
     }
@@ -707,7 +725,9 @@ class DavResourceTest {
             )
         )
         var nrCalled = 0
-        dav.propfind(1, WebDAV.ResourceType, WebDAV.DisplayName) { response, relation ->
+        dav.propfind(1, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
+            item as MultiStatusItem.Response
+            val (response, relation) = item
             when (response.href) {
                 sampleUrl.resolve("/dav/") -> {
                     assertTrue(response.isSuccess())
@@ -773,7 +793,9 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName) { response, relation ->
+        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
+            item as MultiStatusItem.Response
+            val (response, relation) = item
             called = true
             assertTrue(response.isSuccess())
             assertEquals(Response.HrefRelation.SELF, relation)
@@ -799,10 +821,11 @@ class DavResourceTest {
             )
         )
         var called = false
-        dav.propfind(0, WebDAV.DisplayName) { response, _ ->
+        dav.propfind(0, WebDAV.DisplayName).collect { item ->
+            item as MultiStatusItem.Response
             called = true
-            assertEquals(200, response.propstat.first().status.value)
-            assertEquals("Without Status", response[DisplayName::class.java]?.displayName)
+            assertEquals(200, item.response.propstat.first().status.value)
+            assertEquals("Without Status", item.response[DisplayName::class.java]?.displayName)
         }
         assertTrue(called)
     }
@@ -810,7 +833,7 @@ class DavResourceTest {
     @Test
     fun `propfind sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
-        davResource(engine).propfind(0, WebDAV.ResourceType) { _, _ -> }
+        davResource(engine).propfind(0, WebDAV.ResourceType).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("PROPFIND"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -842,9 +865,10 @@ class DavResourceTest {
         dav.proppatch(
             setProperties = mapOf(Pair(Property.Name("sample", "setThis"), "Some Value")),
             removeProperties = listOf(Property.Name("sample", "removeThis"))
-        ) { _, hrefRelation ->
+        ).collect { item ->
+            item as MultiStatusItem.Response
             called = true
-            assertEquals(Response.HrefRelation.SELF, hrefRelation)
+            assertEquals(Response.HrefRelation.SELF, item.relation)
         }
         assertTrue(called)
     }
@@ -867,7 +891,7 @@ class DavResourceTest {
     @Test
     fun `proppatch sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
-        davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()) { _, _ -> }
+        davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()).collect { }
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("PROPPATCH"), method)
             assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
@@ -952,9 +976,10 @@ class DavResourceTest {
         )
         val dav = davResource(engine)
         var called = false
-        dav.search("<TEST/>") { response, hrefRelation ->
-            assertEquals(Response.HrefRelation.SELF, hrefRelation)
-            assertEquals("Found something", response[DisplayName::class.java]?.displayName)
+        dav.search("<TEST/>").collect { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Response.HrefRelation.SELF, item.relation)
+            assertEquals("Found something", item.response[DisplayName::class.java]?.displayName)
             called = true
         }
         assertTrue(called)

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DavResourceTest.kt
@@ -40,6 +40,8 @@ import io.ktor.http.contentType
 import io.ktor.http.fullPath
 import io.ktor.http.headersOf
 import io.ktor.http.withCharset
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -464,37 +466,20 @@ class DavResourceTest {
     @Test
     fun `propfind 500 Internal Server Error throws HttpException`() = runTest {
         val dav = davResource(MockEngine { respondError(HttpStatusCode.InternalServerError) })
-        var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
+            dav.propfind(0, WebDAV.ResourceType).toList()
             fail("Expected HttpException")
         } catch (_: HttpException) {
-            assertFalse(called)
         }
     }
 
     @Test
     fun `propfind 200 OK throws DavException`() = runTest {
         val dav = davResource(MockEngine { respondOk() })
-        var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
+            dav.propfind(0, WebDAV.ResourceType).toList()
             fail("Expected DavException")
         } catch (_: DavException) {
-            assertFalse(called)
-        }
-    }
-
-    @Test
-    fun `propfind is not sent before flow is collected`() = runTest {
-        val dav = davResource(MockEngine { respondError(HttpStatusCode.InternalServerError) })
-        // building the flow must not trigger the request or throw
-        val flow = dav.propfind(0, WebDAV.ResourceType)
-        try {
-            flow.collect { }
-            fail("Expected HttpException")
-        } catch (_: HttpException) {
-            // expected only once the flow is collected
         }
     }
 
@@ -503,12 +488,10 @@ class DavResourceTest {
         val dav = davResource(MockEngine {
             respond("<html></html>", HttpStatusCode.MultiStatus, headersOf(HttpHeaders.ContentType, ContentType.Text.Html.toString()))
         })
-        var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
+            dav.propfind(0, WebDAV.ResourceType).toList()
             fail("Expected DavException")
         } catch (_: DavException) {
-            assertFalse(called)
         }
     }
 
@@ -520,24 +503,20 @@ class DavResourceTest {
                 headersOf(HttpHeaders.ContentType, ContentType.Application.Xml.withCharset(Charsets.UTF_8).toString())
             )
         })
-        var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
+            dav.propfind(0, WebDAV.ResourceType).toList()
             fail("Expected DavException")
         } catch (_: DavException) {
-            assertFalse(called)
         }
     }
 
     @Test
     fun `propfind no multistatus root throws DavException`() = runTest {
         val dav = davResource(propfindEngine("<test></test>"))
-        var called = false
         try {
-            dav.propfind(0, WebDAV.ResourceType).collect { called = true }
+            dav.propfind(0, WebDAV.ResourceType).toList()
             fail("Expected DavException")
         } catch (_: DavException) {
-            assertFalse(called)
         }
     }
 
@@ -553,14 +532,9 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType).collect { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertEquals(HttpStatusCode.InternalServerError, item.response.status)
-            called = true
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType).single() as MultiStatusItem.Response
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertEquals(HttpStatusCode.InternalServerError, item.response.status)
     }
 
     @Test
@@ -575,14 +549,9 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType).collect { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertEquals(HttpStatusCode.Forbidden, item.response.status)
-            called = true
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType).single() as MultiStatusItem.Response
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertEquals(HttpStatusCode.Forbidden, item.response.status)
     }
 
     @Test
@@ -600,20 +569,15 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType).collect { item ->
-            item as MultiStatusItem.Response
-            called = true
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertTrue(item.response.properties.filterIsInstance<ResourceType>().isEmpty())
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType).single() as MultiStatusItem.Response
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertTrue(item.response.properties.filterIsInstance<ResourceType>().isEmpty())
     }
 
     @Test
-    fun `propfind no response elements callback not called`() = runTest {
+    fun `propfind no response elements emits nothing`() = runTest {
         val dav = davResource(propfindEngine("<multistatus xmlns='DAV:'></multistatus>"))
-        dav.propfind(0, WebDAV.ResourceType).collect { fail("Shouldn't be called") }
+        assertTrue(dav.propfind(0, WebDAV.ResourceType).toList().isEmpty())
     }
 
     @Test
@@ -628,15 +592,10 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType).collect { item ->
-            item as MultiStatusItem.Response
-            called = true
-            assertTrue(item.response.isSuccess())
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertEquals(0, item.response.properties.size)
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType).single() as MultiStatusItem.Response
+        assertTrue(item.response.isSuccess())
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertEquals(0, item.response.properties.size)
     }
 
     @Test
@@ -657,15 +616,10 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
-            item as MultiStatusItem.Response
-            called = true
-            assertTrue(item.response.isSuccess())
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertEquals("My DAV Collection", item.response[DisplayName::class.java]?.displayName)
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).single() as MultiStatusItem.Response
+        assertTrue(item.response.isSuccess())
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertEquals("My DAV Collection", item.response[DisplayName::class.java]?.displayName)
     }
 
     @Test
@@ -725,8 +679,8 @@ class DavResourceTest {
             )
         )
         var nrCalled = 0
-        dav.propfind(1, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
-            item as MultiStatusItem.Response
+        val items = dav.propfind(1, WebDAV.ResourceType, WebDAV.DisplayName).toList()
+        items.filterIsInstance<MultiStatusItem.Response>().forEach { item ->
             val (response, relation) = item
             when (response.href) {
                 sampleUrl.resolve("/dav/") -> {
@@ -792,18 +746,13 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).collect { item ->
-            item as MultiStatusItem.Response
-            val (response, relation) = item
-            called = true
-            assertTrue(response.isSuccess())
-            assertEquals(Response.HrefRelation.SELF, relation)
-            assertEquals(sampleUrl.resolve("/dav/"), response.href)
-            assertTrue(response[ResourceType::class.java]!!.types.contains(WebDAV.Collection))
-            assertEquals("My DAV Collection", response[DisplayName::class.java]?.displayName)
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.ResourceType, WebDAV.DisplayName).single() as MultiStatusItem.Response
+        val (response, relation) = item
+        assertTrue(response.isSuccess())
+        assertEquals(Response.HrefRelation.SELF, relation)
+        assertEquals(sampleUrl.resolve("/dav/"), response.href)
+        assertTrue(response[ResourceType::class.java]!!.types.contains(WebDAV.Collection))
+        assertEquals("My DAV Collection", response[DisplayName::class.java]?.displayName)
     }
 
     @Test
@@ -820,20 +769,15 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.propfind(0, WebDAV.DisplayName).collect { item ->
-            item as MultiStatusItem.Response
-            called = true
-            assertEquals(200, item.response.propstat.first().status.value)
-            assertEquals("Without Status", item.response[DisplayName::class.java]?.displayName)
-        }
-        assertTrue(called)
+        val item = dav.propfind(0, WebDAV.DisplayName).single() as MultiStatusItem.Response
+        assertEquals(200, item.response.propstat.first().status.value)
+        assertEquals("Without Status", item.response[DisplayName::class.java]?.displayName)
     }
 
     @Test
     fun `propfind sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
-        davResource(engine).propfind(0, WebDAV.ResourceType).collect { }
+        davResource(engine).propfind(0, WebDAV.ResourceType).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("PROPFIND"), method)
             assertEquals("0", headers[HttpHeaders.Depth])
@@ -861,16 +805,11 @@ class DavResourceTest {
                         "</multistatus>"
             )
         )
-        var called = false
-        dav.proppatch(
+        val item = dav.proppatch(
             setProperties = mapOf(Pair(Property.Name("sample", "setThis"), "Some Value")),
             removeProperties = listOf(Property.Name("sample", "removeThis"))
-        ).collect { item ->
-            item as MultiStatusItem.Response
-            called = true
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-        }
-        assertTrue(called)
+        ).single() as MultiStatusItem.Response
+        assertEquals(Response.HrefRelation.SELF, item.relation)
     }
 
     @Test
@@ -891,7 +830,7 @@ class DavResourceTest {
     @Test
     fun `proppatch sends proper request`() = runTest {
         val engine = propfindEngine("<multistatus xmlns='DAV:'></multistatus>")
-        davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()).collect { }
+        davResource(engine).proppatch(setProperties = emptyMap(), removeProperties = emptyList()).toList()
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("PROPPATCH"), method)
             assertEquals(DavResource.MIME_XML_UTF8, body.contentType)
@@ -975,14 +914,9 @@ class DavResourceTest {
                     "</multistatus>"
         )
         val dav = davResource(engine)
-        var called = false
-        dav.search("<TEST/>").collect { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-            assertEquals("Found something", item.response[DisplayName::class.java]?.displayName)
-            called = true
-        }
-        assertTrue(called)
+        val item = dav.search("<TEST/>").single() as MultiStatusItem.Response
+        assertEquals(Response.HrefRelation.SELF, item.relation)
+        assertEquals("Found something", item.response[DisplayName::class.java]?.displayName)
         with(engine.requestHistory.last()) {
             assertEquals(HttpMethod.parse("SEARCH"), method)
             assertEquals(sampleUrl.encodedPath, url.encodedPath)

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/ResponseParserTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/ResponseParserTest.kt
@@ -12,9 +12,8 @@ package at.bitfire.dav4jvm.ktor
 
 import at.bitfire.dav4jvm.XmlUtils
 import io.ktor.http.Url
-import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.io.StringReader
 
@@ -25,7 +24,7 @@ class ResponseParserTest {
 
 
     @Test
-    fun `parseResponse relation=SELF`() = runTest {
+    fun `parseResponse relation=SELF`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(StringReader("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
                 "<multistatus xmlns=\"DAV:\">\n" +
@@ -46,15 +45,14 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Url("http://www.example.com/container/"), item.response.href)
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(Url("http://www.example.com/container/"), item.response.href)
+        assertEquals(Response.HrefRelation.SELF, item.relation)
     }
 
     @Test
-    fun `parseResponse relation=MEMBER`() = runTest {
+    fun `parseResponse relation=MEMBER`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(StringReader("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
                 "<multistatus xmlns=\"DAV:\">\n" +
@@ -78,15 +76,14 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Url("http://www.example.com/container/front.html"), item.response.href)
-            assertEquals(Response.HrefRelation.MEMBER, item.relation)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(Url("http://www.example.com/container/front.html"), item.response.href)
+        assertEquals(Response.HrefRelation.MEMBER, item.relation)
     }
 
     @Test
-    fun `parseResponse relation=OTHER`() = runTest {
+    fun `parseResponse relation=OTHER`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(StringReader("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
                 "<multistatus xmlns=\"DAV:\">\n" +
@@ -110,15 +107,14 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Url("http://other.example.com/was-not-requested"), item.response.href)
-            assertEquals(Response.HrefRelation.OTHER, item.relation)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(Url("http://other.example.com/was-not-requested"), item.response.href)
+        assertEquals(Response.HrefRelation.OTHER, item.relation)
     }
 
     @Test
-    fun `parseResponse collection href gets trailing slash`() = runTest {
+    fun `parseResponse collection href gets trailing slash`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(
             StringReader(
@@ -137,15 +133,14 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Url("http://www.example.com/container/"), item.response.href)
-            assertEquals(Response.HrefRelation.SELF, item.relation)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(Url("http://www.example.com/container/"), item.response.href)
+        assertEquals(Response.HrefRelation.SELF, item.relation)
     }
 
     @Test
-    fun `parseResponse non-collection href unchanged`() = runTest {
+    fun `parseResponse non-collection href unchanged`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(
             StringReader(
@@ -164,14 +159,13 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(Url("http://www.example.com/container/file.txt"), item.response.href)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(Url("http://www.example.com/container/file.txt"), item.response.href)
     }
 
     @Test
-    fun `parseResponse without href does not emit`() = runTest {
+    fun `parseResponse without href returns null`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(
             StringReader(
@@ -187,13 +181,11 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        var called = false
-        parser.parseResponse(xml) { called = true }
-        assertFalse(called)
+        assertNull(parser.parseResponse(xml))
     }
 
     @Test
-    fun `parseResponse multiple propstats`() = runTest {
+    fun `parseResponse multiple propstats`() {
         val xml = XmlUtils.newPullParser()
         xml.setInput(
             StringReader(
@@ -214,10 +206,9 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { item ->
-            item as MultiStatusItem.Response
-            assertEquals(2, item.response.propstat.size)
-        }
+        val item = parser.parseResponse(xml)
+        item as MultiStatusItem.Response
+        assertEquals(2, item.response.propstat.size)
     }
 
 

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/ResponseParserTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/ResponseParserTest.kt
@@ -46,9 +46,10 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, relation ->
-            assertEquals(Url("http://www.example.com/container/"), response.href)
-            assertEquals(Response.HrefRelation.SELF, relation)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Url("http://www.example.com/container/"), item.response.href)
+            assertEquals(Response.HrefRelation.SELF, item.relation)
         }
     }
 
@@ -77,9 +78,10 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, relation ->
-            assertEquals(Url("http://www.example.com/container/front.html"), response.href)
-            assertEquals(Response.HrefRelation.MEMBER, relation)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Url("http://www.example.com/container/front.html"), item.response.href)
+            assertEquals(Response.HrefRelation.MEMBER, item.relation)
         }
     }
 
@@ -108,9 +110,10 @@ class ResponseParserTest {
         ))
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, relation ->
-            assertEquals(Url("http://other.example.com/was-not-requested"), response.href)
-            assertEquals(Response.HrefRelation.OTHER, relation)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Url("http://other.example.com/was-not-requested"), item.response.href)
+            assertEquals(Response.HrefRelation.OTHER, item.relation)
         }
     }
 
@@ -134,9 +137,10 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, relation ->
-            assertEquals(Url("http://www.example.com/container/"), response.href)
-            assertEquals(Response.HrefRelation.SELF, relation)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Url("http://www.example.com/container/"), item.response.href)
+            assertEquals(Response.HrefRelation.SELF, item.relation)
         }
     }
 
@@ -160,13 +164,14 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, _ ->
-            assertEquals(Url("http://www.example.com/container/file.txt"), response.href)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(Url("http://www.example.com/container/file.txt"), item.response.href)
         }
     }
 
     @Test
-    fun `parseResponse without href does not call callback`() = runTest {
+    fun `parseResponse without href does not emit`() = runTest {
         val xml = XmlUtils.newPullParser()
         xml.setInput(
             StringReader(
@@ -183,7 +188,7 @@ class ResponseParserTest {
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
         var called = false
-        parser.parseResponse(xml) { _, _ -> called = true }
+        parser.parseResponse(xml) { called = true }
         assertFalse(called)
     }
 
@@ -209,8 +214,9 @@ class ResponseParserTest {
         )
         xml.nextTag()   // multistatus
         xml.nextTag()   // response
-        parser.parseResponse(xml) { response, _ ->
-            assertEquals(2, response.propstat.size)
+        parser.parseResponse(xml) { item ->
+            item as MultiStatusItem.Response
+            assertEquals(2, item.response.propstat.size)
         }
     }
 


### PR DESCRIPTION
Closes #204 (part of #200 — moving the ktor-based API from callbacks to `suspend`/`Flow`).

- `MultiResponseCallback` removed; `propfind`, `proppatch`, `search`, `reportChanges`, `addressbookQuery`/`multiget`, `calendarQuery`/`multiget` now return `Flow<MultiStatusItem>` instead of taking a callback.
- New sealed type `MultiStatusItem` (`Response` + `ExtraProperty`) replaces the callback's two arguments and the old separate `List<Property>` return value.
- Added shared `multiStatusFlow` helper in `DavResource` combining `followRedirects` + `processMultiStatus`.

For now acceptable inconsistency in concurrent updating of `location` noted in #209.

Used in / see also: https://github.com/bitfireAT/davx5-ose/pull/2640