### PR TITLE
Fix digest auth

### DIFF
--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
@@ -99,24 +99,36 @@ class PreemptiveBasicDigestAuthProvider(
         before calling this method. Always clear it first so we never send two Authorization headers. */
         request.headers.remove(HttpHeaders.Authorization)
 
-        /* Ktor's DigestAuthProvider takes both the "uri" parameter and HA2 from request.url.fullPath,
-        which remains empty for a URL without a path  (like https://example.com where the trailing slash is missing and
-        as it can be entered by the user during login). It would then send auth param uri="" to the server and hash over
-        "PROPFIND:", but the actual request being sent is "PROPFIND / HTTP/1.1" – so the server's hash can never match
-        ours. Normalizing the path here makes both agree, and doesn't change what is sent.
-        See https://github.com/bitfireAT/dav4jvm/issues/219 */
-        if (request.url.encodedPath.isEmpty())
-            request.url.encodedPath = "/"
-
         /* On a retry, authHeader tells us exactly which scheme (basic vs digest) this response challenged for. Digest
         needs a challenge to read the realm from, see [preemptiveDigestChallenge]. Basic ignores it. */
         val challenge = authHeader ?: preemptiveDigestChallenge
         val provider =
-            if (challenge != null && challenge.authScheme.equals(AuthScheme.Digest, ignoreCase = true))
+            if (challenge != null && challenge.authScheme.equals(AuthScheme.Digest, ignoreCase = true)) {
+                request.workaroundKtorEmptyDigestUri()
                 digestAuthProvider
-            else
+            } else
                 basicAuthProvider
         provider.addRequestHeaders(request, challenge)
     }
 
+}
+
+/**
+ * Workaround for KTOR-9760: ktor's [DigestAuthProvider] takes both the `uri` auth parameter and HA2 from
+ * `Url.fullPath`, which is empty for a URL without a path (like `https://example.com`, where the trailing slash is
+ * missing – as it can be entered by the user during login). It then sends `uri=""` and hashes over `"PROPFIND:"`,
+ * while the request actually sent is `PROPFIND / HTTP/1.1` (required by RFC 9112 3.2.1) – so the server's hash can
+ * never match ours.
+ *
+ * Normalizing the path here makes both agree, and doesn't change what is sent.
+ *
+ * Remove this function together with its call site as soon as the ktor bug is fixed. `KtorDigestEmptyPathTest` pins
+ * the buggy ktor behavior and starts to fail once it is.
+ *
+ * @see <a href="https://youtrack.jetbrains.com/issue/KTOR-9760">ktor bug report</a>
+ * @see <a href="https://github.com/bitfireAT/dav4jvm/issues/219">dav4jvm issue</a>
+ */
+private fun HttpRequestBuilder.workaroundKtorEmptyDigestUri() {
+    if (url.encodedPath.isEmpty())
+        url.encodedPath = "/"
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
@@ -51,13 +51,16 @@ class PreemptiveBasicDigestAuthProvider(
         )
     }
 
-    /* The last Digest challenge received from the server, or null when Basic auth is to be used
-    preemptively (the default, until the server challenges for Digest).
-
-    [digestAuthProvider] takes the realm straight from the challenge it is passed, because it never expects to be used
-    preemptively (its sendWithoutRequest always returns false). We do use it preemptively though, so we have to replay
-    the remembered challenge – otherwise it would compute HA1 over the literal string "null" and omit the realm
-    parameter. Only the realm is taken from it; nonce/qop/opaque come from the state it stored in isApplicable(). */
+    /**
+     *  The last Digest challenge received from the server, or null when Basic auth is to be used
+     *  preemptively (the default, until the server challenges for Digest).
+     *
+     *  [digestAuthProvider] takes the realm straight from the challenge it is passed, because it never expects to be
+     *  used preemptively (its sendWithoutRequest always returns false). We do use it preemptively though, so we have
+     *  to replay the remembered challenge – otherwise it would compute HA1 over the literal string "null" and omit the
+     *  realm parameter. Only the realm is taken from it; nonce/qop/opaque come from the state it stored in
+     *  isApplicable().
+     */
     @Volatile
     private var preemptiveDigestChallenge: HttpAuthHeader? = null
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
@@ -54,15 +54,10 @@ class PreemptiveBasicDigestAuthProvider(
     /* The last Digest challenge received from the server, or null when Basic auth is to be used
     preemptively (the default, until the server challenges for Digest).
 
-    [digestAuthProvider] is only ever asked to build a header in response to a challenge (since its sendWithoutRequest
-    method always returns false - it basically declines preemptive use itself), and takes the realm straight from that
-    challenge. But because we report sendWithoutRequest = true for both basic and digest schemes and then delegate to
-    the correct scheme, we DO(!) use [digestAuthProvider] preemptively. That is, we would hand it a null challenge,
-    making it compute HA1 over the literal string "null" instead of the realm and omit the realm parameter, so the
-    server rejects the request.
-
-    We can prevent this by remembering the challenge and replaying it. Only the realm is taken from it; nonce/qop/opaque
-    come from the state the provider itself stored in isApplicable(). */
+    [digestAuthProvider] takes the realm straight from the challenge it is passed, because it never expects to be used
+    preemptively (its sendWithoutRequest always returns false). We do use it preemptively though, so we have to replay
+    the remembered challenge – otherwise it would compute HA1 over the literal string "null" and omit the realm
+    parameter. Only the realm is taken from it; nonce/qop/opaque come from the state it stored in isApplicable(). */
     @Volatile
     private var preemptiveDigestChallenge: HttpAuthHeader? = null
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProvider.kt
@@ -19,6 +19,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.HttpHeaders
 import io.ktor.http.auth.AuthScheme
 import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.encodedPath
 
 /**
  * An [AuthProvider] that tries Basic auth preemptively and switches to Digest auth (remembered
@@ -50,10 +51,20 @@ class PreemptiveBasicDigestAuthProvider(
         )
     }
 
-    /* Basic is used preemptively by default; switched to Digest once a WWW-Authenticate challenge
-    from the server requests that. Only consulted for preemptive sends (no authHeader to inspect). */
+    /* The last Digest challenge received from the server, or null when Basic auth is to be used
+    preemptively (the default, until the server challenges for Digest).
+
+    [digestAuthProvider] is only ever asked to build a header in response to a challenge (since its sendWithoutRequest
+    method always returns false - it basically declines preemptive use itself), and takes the realm straight from that
+    challenge. But because we report sendWithoutRequest = true for both basic and digest schemes and then delegate to
+    the correct scheme, we DO(!) use [digestAuthProvider] preemptively. That is, we would hand it a null challenge,
+    making it compute HA1 over the literal string "null" instead of the realm and omit the realm parameter, so the
+    server rejects the request.
+
+    We can prevent this by remembering the challenge and replaying it. Only the realm is taken from it; nonce/qop/opaque
+    come from the state the provider itself stored in isApplicable(). */
     @Volatile
-    private var preemptiveProvider: AuthProvider = basicAuthProvider
+    private var preemptiveDigestChallenge: HttpAuthHeader? = null
 
     @Suppress("OverridingDeprecatedMember", "DEPRECATION_ERROR")
     @Deprecated("Please use sendWithoutRequest function instead", level = DeprecationLevel.ERROR)
@@ -66,13 +77,13 @@ class PreemptiveBasicDigestAuthProvider(
         // Check for basicAuthProvider first so that we do not construct digestAuthProvider if not needed
         basicAuthProvider.isApplicable(auth) -> {
             // server requested Basic auth, switch (back) to Basic auth
-            preemptiveProvider = basicAuthProvider
+            preemptiveDigestChallenge = null
             true
         }
 
         digestAuthProvider.isApplicable(auth) -> {
             // server requested Digest auth, switch to Digest auth
-            preemptiveProvider = digestAuthProvider
+            preemptiveDigestChallenge = auth
             true
         }
 
@@ -88,14 +99,24 @@ class PreemptiveBasicDigestAuthProvider(
         before calling this method. Always clear it first so we never send two Authorization headers. */
         request.headers.remove(HttpHeaders.Authorization)
 
-        /* For a retry, authHeader tells us exactly which scheme this response challenged for.
-        Only fall back to preemptiveProvider when there's no challenge to go on, i.e. a purely preemptive send. */
-        val provider = when {
-            authHeader == null -> preemptiveProvider
-            authHeader.authScheme.equals(AuthScheme.Digest, ignoreCase = true) -> digestAuthProvider
-            else -> basicAuthProvider
-        }
-        provider.addRequestHeaders(request, authHeader)
+        /* Ktor's DigestAuthProvider takes both the "uri" parameter and HA2 from request.url.fullPath,
+        which remains empty for a URL without a path  (like https://example.com where the trailing slash is missing and
+        as it can be entered by the user during login). It would then send auth param uri="" to the server and hash over
+        "PROPFIND:", but the actual request being sent is "PROPFIND / HTTP/1.1" – so the server's hash can never match
+        ours. Normalizing the path here makes both agree, and doesn't change what is sent.
+        See https://github.com/bitfireAT/dav4jvm/issues/219 */
+        if (request.url.encodedPath.isEmpty())
+            request.url.encodedPath = "/"
+
+        /* On a retry, authHeader tells us exactly which scheme (basic vs digest) this response challenged for. Digest
+        needs a challenge to read the realm from, see [preemptiveDigestChallenge]. Basic ignores it. */
+        val challenge = authHeader ?: preemptiveDigestChallenge
+        val provider =
+            if (challenge != null && challenge.authScheme.equals(AuthScheme.Digest, ignoreCase = true))
+                digestAuthProvider
+            else
+                basicAuthProvider
+        provider.addRequestHeaders(request, challenge)
     }
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/DigestAuthProviderCongestionTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/DigestAuthProviderCongestionTest.kt
@@ -23,7 +23,8 @@ import org.junit.Test
  * construct a `DigestAuthProvider`, since ktor's nonce buffer is a process-wide singleton that
  * other tests can warm up.
  * Run in isolation, e.g. `./gradlew test --tests "*.DigestAuthProviderCongestionTest"`.
- * `DigestAuthProvider` is not used anywhere else, so this is safe to run.
+ * [PreemptiveBasicDigestAuthProviderTest] and [KtorDigestEmptyPathTest] both construct a `DigestAuthProvider` and
+ * would warm that buffer up.
  * @see <a href="https://youtrack.jetbrains.com/issue/KTOR-9722/DigestAuthProvider-cannot-be-initialized-with-a-congested-Dispatchers.Default-pool">Ktor bug report</a>
  */
 class DigestAuthProviderCongestionTest {

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/KtorDigestEmptyPathTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/KtorDigestEmptyPathTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor
+
+import io.ktor.client.plugins.auth.providers.DigestAuthCredentials
+import io.ktor.client.plugins.auth.providers.DigestAuthProvider
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpHeaders
+import io.ktor.http.URLBuilder
+import io.ktor.http.URLProtocol
+import io.ktor.http.auth.HttpAuthHeader
+import io.ktor.http.auth.parseAuthorizationHeader
+import io.ktor.http.fullPath
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the ktor behavior that `workaroundKtorEmptyDigestUri` in [PreemptiveBasicDigestAuthProvider] compensates for:
+ * for a URL without a path, `Url.fullPath` is empty, and ktor's [DigestAuthProvider] signs that empty string instead
+ * of the `/` that is actually sent as request target (RFC 9112 3.2.1).
+ *
+ * **When one of these tests fails, ktor has fixed the bug and the workaround can be dropped.**
+ *
+ * Note: this class constructs a [DigestAuthProvider], which warms up ktor's process-wide nonce buffer.
+ * See [DigestAuthProviderCongestionTest] for why that matters there.
+ *
+ * @see <a href="https://youtrack.jetbrains.com/issue/KTOR-9760">ktor bug report</a>
+ * @see <a href="https://github.com/bitfireAT/dav4jvm/issues/219">dav4jvm issue</a>
+ */
+class KtorDigestEmptyPathTest {
+
+    /** The root cause, in `ktor-http`. */
+    @Test
+    fun `fullPath is empty for a URL without a path`() {
+        val url = URLBuilder().apply {
+            protocol = URLProtocol.HTTPS
+            host = "domain.example"
+        }.build()
+
+        assertEquals(
+            "KTOR-9760 is fixed (ktor normalizes the empty path now) – remove workaroundKtorEmptyDigestUri()",
+            "",
+            url.fullPath
+        )
+    }
+
+    /** The symptom we actually suffer from, in `ktor-client-auth`. */
+    @Test
+    fun `DigestAuthProvider signs an empty uri for a URL without a path`() = runTest {
+        val digestAuthProvider = DigestAuthProvider(
+            credentials = { DigestAuthCredentials("user", "password") }
+        )
+        val authHeader = parseAuthorizationHeader("""Digest algorithm=MD5, realm="realm", nonce="md5-nonce"""")!!
+
+        // Note: isApplicable() needs to be called before addRequestHeaders()
+        assertTrue(digestAuthProvider.isApplicable(authHeader))
+
+        // URL without any path, as it can be entered by the user during login
+        val request = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        digestAuthProvider.addRequestHeaders(request, authHeader)
+
+        // the uri parameter must match the request target on the wire, which is "/" and not ""
+        val digest =
+            parseAuthorizationHeader(request.headers[HttpHeaders.Authorization]!!) as HttpAuthHeader.Parameterized
+        assertEquals(
+            "KTOR-9760 is fixed (ktor authenticates for the correct path now) – remove workaroundKtorEmptyDigestUri()",
+            "",
+            digest.parameter("uri")
+        )
+    }
+
+}

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProviderTest.kt
@@ -13,6 +13,7 @@ package at.bitfire.dav4jvm.ktor
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.http.HttpHeaders
 import io.ktor.http.URLProtocol
+import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.http.auth.parseAuthorizationHeader
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -145,7 +146,33 @@ class PreemptiveBasicDigestAuthProviderTest {
 
         val authorizationHeaders = request.headers.getAll(HttpHeaders.Authorization)!!
         assertEquals(1, authorizationHeaders.size)
-        assertTrue("""nonce="md5-nonce"""" in authorizationHeaders.single())
+        val digest = parseAuthorizationHeader(authorizationHeaders.single()) as HttpAuthHeader.Parameterized
+        // the realm has to be taken from the remembered challenge, and must not be null
+        assertEquals("realm", digest.parameter("realm"))
+        assertEquals("md5-nonce", digest.parameter("nonce"))
+    }
+
+    @Test
+    fun `addRequestHeaders() authenticates for slash when the URL has no path`() = runTest {
+        val authProvider = PreemptiveBasicDigestAuthProvider(
+            username = "user",
+            password = "password"
+        )
+        val authHeader = parseAuthorizationHeader("""Digest algorithm=MD5, realm="realm", nonce="md5-nonce"""")!!
+        assertTrue(authProvider.isApplicable(authHeader))
+
+        // URL without any path, as it can be entered by the user during login
+        val request = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        authProvider.addRequestHeaders(request, authHeader)
+
+        // the request line on the wire is "GET / HTTP/1.1", so we have to authenticate for "/" and not for ""
+        val digest =
+            parseAuthorizationHeader(request.headers[HttpHeaders.Authorization]!!) as HttpAuthHeader.Parameterized
+        assertEquals("/", digest.parameter("uri"))
     }
 
 }

--- a/src/test/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProviderTest.kt
+++ b/src/test/kotlin/at/bitfire/dav4jvm/ktor/PreemptiveBasicDigestAuthProviderTest.kt
@@ -15,6 +15,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.URLProtocol
 import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.http.auth.parseAuthorizationHeader
+import io.ktor.http.encodedPath
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -173,6 +174,23 @@ class PreemptiveBasicDigestAuthProviderTest {
         val digest =
             parseAuthorizationHeader(request.headers[HttpHeaders.Authorization]!!) as HttpAuthHeader.Parameterized
         assertEquals("/", digest.parameter("uri"))
+    }
+
+    @Test
+    fun `addRequestHeaders() leaves the URL untouched for Basic`() = runTest {
+        // the empty-path normalization is a workaround for a ktor Digest bug, so it must not affect Basic requests
+        val authProvider = PreemptiveBasicDigestAuthProvider(
+            username = "user",
+            password = "password"
+        )
+        val request = HttpRequestBuilder().apply {
+            url.protocol = URLProtocol.HTTPS
+            url.host = "domain.example"
+        }
+
+        authProvider.addRequestHeaders(request, authHeader = null)
+
+        assertEquals("", request.url.encodedPath)
     }
 
 }


### PR DESCRIPTION
Fix 
- incorrect HA2 calculation for URLs without a trailing slash
- sending invalid preemptive Digest credentials, missing realm