### PR TITLE
Add `BadGatewayException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 For more detailed changes, see https://github.com/bitfireAT/dav4jvm/compare/. Example: https://github.com/bitfireAT/dav4jvm/compare/2.1.2...2.1.3
 
 ### 4.0.1 (not released)
-- Add `BadGatewayException` that is thrown for HTTP 502 responses ([#225](https://github.com/bitfireAT/dav4jvm/pull/225)).
+- Add `BadGatewayException` that is thrown for HTTP 502 responses.
+  _This is may be required because some servers may be temporarily not available, and clients may treat it as a soft error and retry the request later._
 
 ### 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 For more detailed changes, see https://github.com/bitfireAT/dav4jvm/compare/. Example: https://github.com/bitfireAT/dav4jvm/compare/2.1.2...2.1.3
 
+### 4.0.1 (not released)
+- Add `BadGatewayException` that is thrown for HTTP 502 responses ([#225](https://github.com/bitfireAT/dav4jvm/pull/225)).
+
 ### 4.0.0
 
 API change: the old synchronous, non-suspending callback pattern (like `MultiResponseCallback`) has been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 For more detailed changes, see https://github.com/bitfireAT/dav4jvm/compare/. Example: https://github.com/bitfireAT/dav4jvm/compare/2.1.2...2.1.3
 
-### 4.0.1 (not released)
+### 4.0.2 (not released)
 - Add `BadGatewayException` that is thrown for HTTP 502 responses.
   _This is may be required because some servers may be temporarily not available, and clients may treat it as a soft error and retry the request later._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ For more detailed changes, see https://github.com/bitfireAT/dav4jvm/compare/. Ex
 
 ### 4.0.2 (not released)
 - Add `BadGatewayException` that is thrown for HTTP 502 responses.
-  _This is may be required because some servers may be temporarily not available, and clients may treat it as a soft error and retry the request later._
+  _DAV Services are often hosted behind a reverse proxy that will respond with a HTTP 502 status code when the actual service is temporarily not available. In most cases clients want to treat this as a soft error and retry the request later._
 
 ### 4.0.0
 

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/BadGatewayException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/BadGatewayException.kt
@@ -22,8 +22,9 @@ class BadGatewayException internal constructor(
 ) {
 
     init {
-        if (responseInfo.status != HttpStatusCode.BadGateway)
-            throw IllegalArgumentException("Status must be ${HttpStatusCode.BadGateway}")
+        require(responseInfo.status == HttpStatusCode.BadGateway) {
+            "Status must be ${HttpStatusCode.BadGateway}"
+        }
     }
 
 }

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/BadGatewayException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/BadGatewayException.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright © All Contributors. See LICENSE and AUTHORS in the root directory for details.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package at.bitfire.dav4jvm.ktor.exception
+
+import io.ktor.http.HttpStatusCode
+
+class BadGatewayException internal constructor(
+    responseInfo: HttpResponseInfo
+): HttpException(
+    status = responseInfo.status,
+    requestExcerpt = responseInfo.requestExcerpt,
+    responseExcerpt = responseInfo.responseExcerpt,
+    errors = responseInfo.errors
+) {
+
+    init {
+        if (responseInfo.status != HttpStatusCode.BadGateway)
+            throw IllegalArgumentException("Status must be ${HttpStatusCode.BadGateway}")
+    }
+
+}

--- a/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/HttpException.kt
+++ b/src/main/kotlin/at/bitfire/dav4jvm/ktor/exception/HttpException.kt
@@ -82,6 +82,9 @@ open class HttpException internal constructor(
                 HttpStatusCode.PreconditionFailed ->    // 412 Precondition failed
                     PreconditionFailedException(responseInfo)
 
+                HttpStatusCode.BadGateway ->            // 502 Bad Gateway
+                    BadGatewayException(responseInfo)
+
                 HttpStatusCode.ServiceUnavailable ->    // 503 Service Unavailable
                     ServiceUnavailableException(
                         responseInfo,


### PR DESCRIPTION
Add a new `BadGatewayException` that is thrown when a server responds with `502`.

This is differentiated because some servers may be temporary not available, and clients may treat it as a soft error, and retry the request later.